### PR TITLE
feat: add AWS CLI auth via IAM Identity Center walkthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@
 MC_SSH_HOST=<lightsail-static-ip-or-dns-name>
 MC_SSH_USER=<ssh-username>
 MC_SSH_KEY=<path-to-pem-file>
+
+# AWS CLI authentication via IAM Identity Center (IdC).
+# MC_AWS_PROFILE is the named profile created by `aws configure sso`. It lives in
+# ~/.aws/config under [profile <name>] and references an [sso-session <name>] block.
+# See docs/aws-auth-setup.md for the full walkthrough (Checkpoints A–F).
+MC_AWS_PROFILE=<aws-sso-profile-name>

--- a/docs/aws-auth-setup.md
+++ b/docs/aws-auth-setup.md
@@ -1,0 +1,211 @@
+# AWS CLI authentication via IAM Identity Center
+
+This walkthrough sets up AWS CLI authentication for this repo using **AWS IAM Identity Center (IdC)** with the
+AWS-managed `AdministratorAccess` permission set. It is the prerequisite for issue #4 (reverse-engineering AWS
+Lightsail into Terraform); issue #5 is independent of this walkthrough.
+
+The agent stops at every checkpoint, presents what's needed, and waits for explicit confirmation before moving on.
+**The configuration is console-driven** — AWS provides no API to enable IdC, and the post-bootstrap surface is
+three resources of marginal value at the current scale of one operator.
+
+## Why IdC over IAM-user access keys
+
+Long-lived IAM access keys are the most common cause of AWS account compromise — they get committed to git,
+harvested from CI logs, or lifted from laptops. IdC issues short-lived credentials backed by an SSO token cached
+on disk for 8–12 hours; the underlying access keys never exist as files. AWS recommends IdC for human users, and
+the modern `sso-session` block in the AWS CLI auto-refreshes those credentials. The trade-off is a one-time
+~30–45 minute setup and a daily `aws sso login` step.
+
+## Prerequisites
+
+- **AWS CLI v2.22 or newer.** The `sso-session` block and PKCE-by-default browser flow used here are stable from
+  v2.22 onward. Install or upgrade via the [AWS CLI install guide][cli-install]; verify with `aws --version`.
+- **A browser** on the same device, for the IdC sign-in flow.
+- **Access to your existing AWS account's root credentials** (or an IAM user with administrative permissions) for
+  Checkpoint A only.
+
+[cli-install]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+
+## Operator vs. agent split
+
+| Checkpoint                                  | Owner              |
+|---------------------------------------------|--------------------|
+| A — Enable Organizations + IdC              | Operator (console) |
+| B — Create user + permission set + assign   | Operator (console) |
+| C — Install AWS CLI v2.22+                  | Operator           |
+| D — Run `aws configure sso`                 | Operator           |
+| E — Populate `.env` with `MC_AWS_PROFILE`   | Operator           |
+| F — Run `scripts/aws/verify-credentials.sh` | Agent + operator   |
+
+## Checkpoint A — Enable Organizations + IAM Identity Center
+
+One console session. Both Organizations and IdC are enabled together by a single button in the IdC console.
+
+1. Sign in to the [AWS Management Console][console] as the root user (or with an IAM user that has administrative
+   permissions).
+2. Open the [IAM Identity Center console][idc-console]. **Set the console region first** — see the irreversible
+   region warning below.
+3. Under **Enable IAM Identity Center**, click **Enable**, and on the next screen confirm
+   **Enable IAM Identity Center with AWS Organizations**. Follow the **Organization (recommended)** tab in
+   [Enable IAM Identity Center][enable-idc].
+
+**Important — the IdC region is irreversible.** Per AWS: "AWS Organizations can have IAM Identity Center enabled
+only in a single AWS Region. After enabling IAM Identity Center, if you need to change the Region that IAM
+Identity Center is enabled in, you must delete the current instance and create an instance in the other Region."
+Deleting and recreating destroys all permission set assignments. Pick deliberately. For a US-based operator,
+`us-east-1` or `us-east-2` is typical and convenient to colocate with LightSail resources.
+
+**Free-tier note.** Per the AWS docs: "If you use a free tier account, creating an AWS organization automatically
+upgrades your account to a paid plan with pay-as-you-go pricing. Your free tier credits expire immediately." If
+you are on the free tier and this matters to you, decide before clicking **Enable**.
+
+**Stop here and confirm with the agent before proceeding to Checkpoint B.**
+
+[console]: https://console.aws.amazon.com/
+
+[idc-console]: https://console.aws.amazon.com/singlesignon/
+
+[enable-idc]: https://docs.aws.amazon.com/singlesignon/latest/userguide/get-started-enable-identity-center.html
+
+## Checkpoint B — Create your operator user, permission set, and assignment
+
+One console session. All three sub-steps stay inside the IdC console you already have open.
+
+1. **Add yourself as an IdC user** in the built-in identity store. Follow [Add users to your Identity Center
+   directory][add-user]. Choose **Send an email to this user with password setup instructions** and use an email
+   you can access right now — the invitation expires in seven days. The username and email cannot be changed
+   later.
+2. **Create the `AdministratorAccess` permission set** as a **predefined permission set**, not a custom one. In
+   the IdC console, under **Multi-account permissions → Permission sets → Create permission set**, select
+   **Predefined permission set**, then **AdministratorAccess** from the list. Follow [Create a permission
+   set][create-perm-set]. `AdministratorAccess` is an [AWS-managed policy][admin-access] that grants full access
+   (`Action: *`, `Resource: *`).
+3. **Assign the permission set to your user** against your AWS account. Under **Multi-account permissions → AWS
+   accounts**, select your account checkbox, click **Assign users or groups**, choose your user, choose the
+   `AdministratorAccess` permission set, and submit. Follow [Assign user or group access to AWS accounts][assign].
+4. **Accept the invitation email and complete first sign-in**, which prompts MFA enrollment. The default IdC
+   authentication mode is **"Every time they sign in (always-on)"** (see [Prompt users for MFA][mfa-prompt]),
+   which means you'll be prompted to register an MFA device on first login and prompted for it on every
+   subsequent sign-in. Use an authenticator app or a security key. **Do not change the MFA mode to "disabled".**
+
+**Stop here and confirm with the agent before proceeding to Checkpoint C.** Note your **AWS access portal URL**
+from the IdC console **Settings → Identity source → AWS access portal URL** — you'll need it in Checkpoint D.
+
+[add-user]: https://docs.aws.amazon.com/singlesignon/latest/userguide/addusers.html
+
+[create-perm-set]: https://docs.aws.amazon.com/singlesignon/latest/userguide/howtocreatepermissionset.html
+
+[admin-access]: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AdministratorAccess.html
+
+[assign]: https://docs.aws.amazon.com/singlesignon/latest/userguide/assignusers.html
+
+[mfa-prompt]: https://docs.aws.amazon.com/singlesignon/latest/userguide/mfa-getting-started.html
+
+## Checkpoint C — Install AWS CLI v2.22 or newer
+
+Follow the [AWS CLI install guide][cli-install] for your OS (macOS GUI installer, Linux command-line installer,
+or Windows MSI). Confirm the installed version meets the v2.22+ floor:
+
+```bash
+aws --version
+```
+
+The agent will assert this in Checkpoint F. **Stop here and confirm with the agent before proceeding to
+Checkpoint D.**
+
+## Checkpoint D — Run `aws configure sso`
+
+This step writes the `[profile <name>]` and `[sso-session <name>]` blocks to `~/.aws/config`. Use the **modern
+sso-session flow**, not the legacy form: only the modern form auto-refreshes credentials from the cached SSO
+token. See [Configuring IAM Identity Center authentication with the AWS CLI][cli-sso].
+
+In a terminal, run:
+
+```bash
+aws configure sso
+```
+
+You'll see these prompts in order. Suggested answers:
+
+| Prompt                            | Enter                                                                                 |
+|-----------------------------------|---------------------------------------------------------------------------------------|
+| `SSO session name (Recommended):` | A short label, e.g., `mc-aws`. Don't leave blank (that triggers legacy form).         |
+| `SSO start URL [None]:`           | The AWS access portal URL from Checkpoint B (e.g., `https://<id>.awsapps.com/start`). |
+| `SSO region [None]:`              | The region you enabled IdC in during Checkpoint A.                                    |
+| `SSO registration scopes [None]:` | `sso:account:access` (default — sufficient for `AdministratorAccess`).                |
+
+The CLI then opens your browser for the IdC sign-in (PKCE flow, default from v2.22+). If only one account/role is
+available, the CLI auto-selects it. Continue:
+
+| Prompt                                               | Enter                                                          |
+|------------------------------------------------------|----------------------------------------------------------------|
+| `Default client Region [None]:`                      | The AWS region where your LightSail / other resources live.    |
+| `CLI default output format (json if not specified):` | `json` (Terraform and scripts assume JSON).                    |
+| `Profile name [...]:`                                | A short name, e.g., `mc-aws`. Save this — goes in `.env` next. |
+
+The profile name you enter here is the value you'll set as `MC_AWS_PROFILE` in Checkpoint E.
+
+**Stop here and confirm with the agent before proceeding to Checkpoint E.**
+
+[cli-sso]: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html
+
+## Checkpoint E — Populate `.env`
+
+If `.env` does not yet exist at the repo root, copy the template:
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` in your editor and set `MC_AWS_PROFILE` to the profile name from Checkpoint D:
+
+```bash
+MC_AWS_PROFILE=mc-aws
+```
+
+`.env` is gitignored. Never commit it.
+
+**Stop here and confirm with the agent before proceeding to Checkpoint F.**
+
+## Checkpoint F — Verify
+
+The agent runs the verify script:
+
+```bash
+./scripts/aws/verify-credentials.sh
+```
+
+This is read-only. It asserts:
+
+- AWS CLI v2.22+ on `PATH`.
+- `MC_AWS_PROFILE` is set (from env or `.env`) and isn't a placeholder.
+- The profile has a region configured.
+- `aws sts get-caller-identity` succeeds with an ARN matching the IdC AdministratorAccess shape:
+  `arn:aws:sts::<account-id>:assumed-role/AWSReservedSSO_AdministratorAccess_<hash>/<username>`.
+
+A clean exit prints the profile name, region, account ID, and ARN. On any failure the script prints the
+copy-paste-able recovery command (typically `aws sso login --profile <name>`) and exits non-zero.
+
+When pasting verify output into the PR description, decide whether to redact the account ID. The ARN hash and
+username are non-sensitive but identify the operator.
+
+## Cleanup / switching identities
+
+To clear the cached SSO token (e.g., when switching IdC users or profiles):
+
+```bash
+aws sso logout --profile "$MC_AWS_PROFILE"
+```
+
+To re-authenticate after the token expires (typically 8–12 hours):
+
+```bash
+aws sso login --profile "$MC_AWS_PROFILE"
+```
+
+## Future trigger (not a deliverable)
+
+If a second operator joins or a CI/CD federation (e.g., GitHub Actions OIDC) is added, the IdC user, permission
+set, and assignment should migrate to IaC — likely Terraform with the `aws_identitystore_user`,
+`aws_ssoadmin_permission_set`, and `aws_ssoadmin_account_assignment` resources. There is no commitment of when or
+whether this happens; the trigger is a real second operator or a real CI use case, not anticipated future scale.

--- a/scripts/aws/verify-credentials.sh
+++ b/scripts/aws/verify-credentials.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# Verify AWS CLI credentials are configured for the operator's IAM Identity Center profile.
+#
+# Read-only. Run after Checkpoint E of docs/aws-auth-setup.md (and any time you suspect
+# the SSO token has expired or the profile drifted). Exit 0 on success; non-zero with a
+# copy-paste-able recovery command on failure.
+
+set -euo pipefail
+
+readonly REQUIRED_CLI_MAJOR=2
+readonly REQUIRED_CLI_MINOR=22
+readonly INSTALL_DOC_URL="https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+readonly SSO_DOC_URL="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html"
+readonly EXPECTED_ARN_PATTERN='^arn:aws:sts::[0-9]+:assumed-role/AWSReservedSSO_AdministratorAccess_[A-Za-z0-9]+/'
+
+err() {
+  printf 'verify-credentials: %s\n' "$*" >&2
+}
+
+script_dir() {
+  cd "$(dirname "$0")" && pwd
+}
+
+repo_root() {
+  cd "$(script_dir)/../.." && pwd
+}
+
+check_aws_cli() {
+  if ! command -v aws >/dev/null 2>&1; then
+    err "AWS CLI not found on PATH."
+    err "Install AWS CLI v${REQUIRED_CLI_MAJOR}.${REQUIRED_CLI_MINOR}+ from:"
+    err "  ${INSTALL_DOC_URL}"
+    exit 1
+  fi
+
+  local version_line version major minor
+  version_line=$(aws --version 2>&1)
+  version=$(printf '%s\n' "$version_line" | sed -E 's|^aws-cli/([0-9]+\.[0-9]+).*|\1|')
+
+  if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+    err "Could not parse AWS CLI version from: ${version_line}"
+    err "Expected output starting with 'aws-cli/<major>.<minor>.<patch>'."
+    exit 1
+  fi
+
+  major=$(printf '%s' "$version" | cut -d. -f1)
+  minor=$(printf '%s' "$version" | cut -d. -f2)
+
+  if [ "$major" -lt "$REQUIRED_CLI_MAJOR" ] \
+    || { [ "$major" -eq "$REQUIRED_CLI_MAJOR" ] && [ "$minor" -lt "$REQUIRED_CLI_MINOR" ]; }; then
+    err "AWS CLI v${major}.${minor} detected; need v${REQUIRED_CLI_MAJOR}.${REQUIRED_CLI_MINOR}+"
+    err "(the modern sso-session block and PKCE auth are stable from v${REQUIRED_CLI_MAJOR}.${REQUIRED_CLI_MINOR})."
+    err "Upgrade: ${INSTALL_DOC_URL}"
+    exit 1
+  fi
+}
+
+resolve_profile() {
+  if [ -n "${MC_AWS_PROFILE:-}" ]; then
+    printf '%s' "$MC_AWS_PROFILE"
+    return 0
+  fi
+
+  local env_file
+  env_file="$(repo_root)/.env"
+  if [ -f "$env_file" ]; then
+    local from_env
+    from_env=$(grep -E '^MC_AWS_PROFILE=' "$env_file" | head -n1 | cut -d= -f2-)
+    from_env=${from_env%\"}
+    from_env=${from_env#\"}
+    from_env=${from_env%\'}
+    from_env=${from_env#\'}
+    if [ -n "$from_env" ]; then
+      printf '%s' "$from_env"
+      return 0
+    fi
+  fi
+
+  err "MC_AWS_PROFILE is not set in env or .env."
+  err "Recover with:"
+  err "  cp .env.example .env && \$EDITOR .env"
+  err "and set MC_AWS_PROFILE to the profile name from 'aws configure sso'."
+  exit 1
+}
+
+reject_placeholder() {
+  local profile=$1
+  if [[ "$profile" == \<*\> ]]; then
+    err "MC_AWS_PROFILE looks like an unfilled placeholder ('${profile}')."
+    err "Replace it with the real profile name from 'aws configure sso'."
+    err "  ${SSO_DOC_URL}"
+    exit 1
+  fi
+}
+
+check_region() {
+  local profile=$1 region
+  region=$(aws configure get region --profile "$profile" 2>/dev/null || true)
+
+  if [ -z "$region" ]; then
+    err "Profile '${profile}' has no region set (or the profile does not exist) in ~/.aws/config."
+    err "LightSail is region-scoped; downstream Terraform drift detection would silently target the wrong region."
+    err "Recover by re-running:"
+    err "  aws configure sso"
+    err "and entering '${profile}' as the profile name (or edit ~/.aws/config to set 'region = <aws-region>')."
+    exit 1
+  fi
+
+  printf '%s' "$region"
+}
+
+check_identity() {
+  local profile=$1 out arn account
+  if ! out=$(aws sts get-caller-identity \
+              --profile "$profile" \
+              --output text \
+              --query '[Arn,Account]' 2>&1); then
+    err "aws sts get-caller-identity failed for profile '${profile}':"
+    printf '  %s\n' "$out" >&2
+    err ""
+    err "If the SSO token is expired (most common cause), recover with:"
+    err "  aws sso login --profile ${profile}"
+    err ""
+    err "If the profile is missing or misconfigured, re-run:"
+    err "  aws configure sso"
+    err "  ${SSO_DOC_URL}"
+    exit 1
+  fi
+
+  arn=$(printf '%s\n' "$out" | awk 'NR==1 {print $1}')
+  account=$(printf '%s\n' "$out" | awk 'NR==1 {print $2}')
+
+  if ! printf '%s' "$arn" | grep -Eq "$EXPECTED_ARN_PATTERN"; then
+    err "Caller ARN does not match the expected IdC AdministratorAccess shape:"
+    err "  Got:      ${arn}"
+    err "  Expected: arn:aws:sts::<account-id>:assumed-role/AWSReservedSSO_AdministratorAccess_<hash>/<username>"
+    err ""
+    err "Common causes:"
+    err "  - Logged in with an IAM user (long-lived access key) instead of IdC."
+    err "  - Permission set is not 'AdministratorAccess' (e.g., 'PowerUserAccess', 'ViewOnlyAccess')."
+    err "  - Different role assumed via 'aws sts assume-role' or an STS profile chain."
+    err ""
+    err "Re-run 'aws configure sso' with AdministratorAccess, then: aws sso login --profile ${profile}"
+    exit 1
+  fi
+
+  printf '%s\t%s' "$arn" "$account"
+}
+
+main() {
+  check_aws_cli
+
+  local profile
+  profile=$(resolve_profile)
+  reject_placeholder "$profile"
+
+  local region
+  region=$(check_region "$profile")
+
+  local identity arn account
+  identity=$(check_identity "$profile")
+  arn=$(printf '%s' "$identity" | cut -f1)
+  account=$(printf '%s' "$identity" | cut -f2)
+
+  printf '\n'
+  printf 'verify-credentials: OK\n'
+  printf '  profile : %s\n' "$profile"
+  printf '  region  : %s\n' "$region"
+  printf '  account : %s\n' "$account"
+  printf '  arn     : %s\n' "$arn"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `docs/aws-auth-setup.md` — operator walkthrough for AWS CLI authentication via IAM Identity Center
  (Checkpoints A–F), with every canonical AWS doc URL cited inline. Modern `sso-session` flow only; legacy form
  is called out and avoided.
- Add `scripts/aws/verify-credentials.sh` — read-only verification gate at Checkpoint F. Asserts AWS CLI v2.22+,
  `MC_AWS_PROFILE` set (env or `.env`), region configured, and an `AWSReservedSSO_AdministratorAccess_*`-shaped
  ARN. `shellcheck`-clean, idempotent, macOS bash 3.2-compatible, no `jq` dependency.
- Update `.env.example` — document `MC_AWS_PROFILE` with a placeholder value and a pointer to the walkthrough.

Closes #6

## Test plan

- [x] All six checkpoints (A–F) executed end-to-end against the operator's live AWS account.
- [x] `shellcheck scripts/aws/verify-credentials.sh` exits clean (v0.11.0).
- [x] `scripts/aws/verify-credentials.sh` exits 0 against the live IdC config.
- [x] Returned ARN matches the expected `arn:aws:sts::<account>:assumed-role/AWSReservedSSO_AdministratorAccess_<hash>/<username>` shape.
- [x] Smoke-tested the AWS-CLI-missing failure path: script fails loudly with the install-doc URL and exit 1.
- [x] No AWS credentials, account IDs, ARNs, SSO start URLs, or `~/.aws/` content in committed files.

## Verify output (account ID redacted)

```
verify-credentials: OK
  profile : mc-aws
  region  : us-east-1
  account : <redacted>
  arn     : arn:aws:sts::<redacted>:assumed-role/AWSReservedSSO_AdministratorAccess_<hash>/brandonavant
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
