### PR TITLE
feat: reverse-engineer LightSail infra into Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,15 @@ terraform.rc
 
 # OS artifacts (optional)
 .DS_Store
+
+# AWS inventory snapshots — operator-specific data (other account IDs in
+# bucket names, DNS records for personal domains, M365 verification tokens,
+# IAM usernames). Generated locally by scripts/aws/inventory.sh; never
+# committed.
+infra/aws-inventory.json
+infra/aws-inventory.*.json
+
+# Real backend configuration — bucket / table / profile names are operator-specific.
+# Only the *.hcl.example template is committed; copy it to *.hcl and fill in your
+# own values from the bootstrap layer's outputs.
+infra/backend-configs/*.hcl

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.44.0"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,161 @@
+# `infra/` — main Terraform layer
+
+This layer manages the AWS resources that back the live LightSail Minecraft deployment. It uses the S3 bucket and
+DynamoDB table created by `infra/bootstrap/` for remote state and locking.
+
+The configuration was reverse-engineered from a hand-built deployment (issue #4). The first apply imports existing
+resources rather than creating new ones; after that, the layer is the source of truth.
+
+## Operator vs. agent split
+
+| Command                           | Owner    | Notes                                                  |
+|-----------------------------------|----------|--------------------------------------------------------|
+| First `terraform init`            | Operator | First-time AWS init goes by hand for visibility.       |
+| Subsequent `terraform init`       | Agent    | Re-init after lock-file or backend-config edits.       |
+| `terraform validate` / `fmt`      | Agent    | Routine authoring.                                     |
+| `terraform plan`                  | Agent    | Required before any apply.                             |
+| `terraform import`                | Agent    | State-only mutation; doesn't touch cloud.              |
+| `terraform state rm` / `state mv` | Agent    | For fixing botched imports.                            |
+| `terraform apply` / `destroy`     | Operator | Cloud-resource mutation; never run by the agent.       |
+
+## First-run workflow
+
+Prerequisites:
+
+- The bootstrap layer is applied (`infra/bootstrap/`) and you have its outputs (`state_bucket_name`,
+  `lock_table_name`, `region`) handy for the backend-config step below.
+- `MC_AWS_PROFILE` is populated in `.env` and `./scripts/aws/verify-credentials.sh` exits clean.
+- Terraform 1.5.0+ on `PATH`.
+
+Steps:
+
+1. **Operator** — copy the backend-config template and fill in your bootstrap layer's outputs:
+
+    ```bash
+    cd infra
+    cp backend-configs/prod.hcl.example backend-configs/prod.hcl
+    $EDITOR backend-configs/prod.hcl   # set bucket, dynamodb_table, profile
+    ```
+
+   The real `prod.hcl` is gitignored — its bucket / table / profile values are
+   operator-specific and don't belong in a public repo.
+
+2. **Operator** — initialize with the prod backend config:
+
+    ```bash
+    terraform init -backend-config=backend-configs/prod.hcl
+    ```
+
+3. **Agent** — runs `terraform import` once per existing live resource (see [Import map](#import-map)).
+   After each import, the agent runs `terraform plan` to catch shape mismatches and adjusts the `.tf` files until
+   plan is clean for that resource.
+
+4. **Agent** — runs a final `terraform plan`. It must report **zero changes** for everything that was imported.
+   The output is captured for the PR description.
+
+5. **Operator** — runs `terraform apply` to materialize the resources that could not be imported (the
+   `aws_lightsail_instance_public_ports.mcserver` resource — see
+   [Resources that can't be imported](#resources-that-cant-be-imported)). The apply is a no-op against AWS for
+   firewall rules, since the desired ports already match the live state, but it adds the resource to Terraform
+   state.
+
+6. **Agent** — runs one more `terraform plan`. From this point on, plan should report zero changes.
+
+## Import map
+
+Each line is the `terraform import` command for an existing live resource:
+
+```bash
+terraform import aws_lightsail_instance.mcserver               mcserver-prod
+terraform import aws_lightsail_disk.mcserver_data              disk-mcserver-prod
+terraform import aws_lightsail_disk_attachment.mcserver_data   'disk-mcserver-prod,mcserver-prod'
+terraform import aws_lightsail_static_ip.mcserver              ip-mcserver-prod
+terraform import aws_lightsail_static_ip_attachment.mcserver   ip-mcserver-prod
+terraform import aws_route53_record.mc                         'Z09024551TI8L9018Y7IE_mc.bytehorizonforge.com_A'
+```
+
+The `bytehorizonforge.com` Route 53 zone is **not** imported — it is read via a `data` source instead. See
+[Why the bytehorizonforge zone is a data source](#why-the-bytehorizonforge-zone-is-a-data-source).
+
+## Resources that can't be imported
+
+Three categories of resources exist in the live deployment but aren't (or can't be) brought into Terraform import
+state. Each is handled deliberately:
+
+- **`aws_lightsail_instance_public_ports.mcserver`** — the AWS provider does not implement `ImportState` for this
+  resource (verified against the v6.44.0 source). It is declared in `lightsail.tf` matching the live firewall rules
+  byte-for-byte, so the first `terraform apply` issues a no-op `PutInstancePublicPorts` API call and adds the
+  resource to state without changing AWS-side behavior.
+- **The `ssh-mcserver` Lightsail key pair** — the AWS provider documentation explicitly says: "You cannot import
+  Lightsail Key Pairs because the private and public key are only available on initial creation." The instance
+  references the key pair by name (`key_pair_name = "ssh-mcserver"`), but the key pair itself stays out of Terraform
+  state. The PEM file the operator already holds is the only copy.
+- **LightSail instance snapshots** — the AWS provider (v6.44.0) does not have an
+  `aws_lightsail_instance_snapshot` resource at all. Existing snapshots live in AWS independently of Terraform; the
+  AutoSnapshot add-on on the instance creates new ones daily as configured (`snapshot_time = "11:00"` UTC).
+
+## Why the bytehorizonforge zone is a data source
+
+The `bytehorizonforge.com.` zone pre-existed this project and hosts records for unrelated concerns — specifically
+an Azure M365 email setup at `auth.bytehorizonforge.com.` (MX, TXT, two DKIM CNAMEs). The Minecraft Terraform does
+**not** own that zone; it merely places one record (`mc.bytehorizonforge.com.`) inside it.
+
+Expressing that with a `data "aws_route53_zone"` block instead of `resource "aws_route53_zone"` keeps the ownership
+boundary truthful: Terraform looks up the zone, but cannot create it, modify it, or destroy it. Zone-level
+attributes (NS, SOA, comment, tags) and unrelated records are entirely outside this stack's reach.
+
+If the zone ever becomes Minecraft-only (e.g., the Azure email records are retired or migrated), the data source
+can be flipped to a resource block by replacing `data "aws_route53_zone"` with `resource "aws_route53_zone"`,
+adding it to state via `terraform import aws_route53_zone.bytehorizonforge <zone_id>`, and updating the `aws_route53_record.mc`
+reference from `data.…` to `aws_route53_zone.bytehorizonforge.zone_id`.
+
+## Drift detection
+
+The primary drift signal is `terraform plan` against the imported state — when something has changed in AWS that
+Terraform manages, plan will show it.
+
+For drift in resources Terraform **doesn't** manage (e.g., the LightSail key pair, instance snapshots, the
+unrelated `auth.*` records in the `bytehorizonforge.com` zone), the inventory script is the cross-check:
+
+```bash
+# Keep a local baseline once you're at a known-good state.
+./scripts/aws/inventory.sh
+cp infra/aws-inventory.json infra/aws-inventory.baseline.json
+
+# Later, regenerate and diff manually.
+./scripts/aws/inventory.sh
+diff infra/aws-inventory.baseline.json infra/aws-inventory.json
+```
+
+Both files are gitignored — the snapshot pulls in operator-specific data (cross-account bucket names, personal
+domain DNS records, Azure M365 verification tokens, IAM usernames) that doesn't belong in a public repo even with
+the AWS account ID redacted.
+
+## Tags
+
+The imported resources currently have no tags. Tags were intentionally omitted from the initial `.tf` files so the
+imported state matches the live deployment exactly and `terraform plan` reports zero changes. A follow-up PR can
+add `default_tags` once the import is verified — that PR's plan will show "add tags" on every resource, which is
+expected.
+
+## File layout
+
+| File              | Concern                                                                |
+|-------------------|------------------------------------------------------------------------|
+| `providers.tf`    | Terraform + AWS provider version pins; S3 backend block.               |
+| `variables.tf`    | `region`, `aws_profile`.                                               |
+| `lightsail.tf`    | LightSail instance + firewall rules.                                   |
+| `storage.tf`      | Attached data disk + disk attachment.                                  |
+| `networking.tf`   | Static IP + IP-to-instance attachment.                                 |
+| `dns.tf`          | `bytehorizonforge.com` Route 53 zone + `mc.` A record.                 |
+| `outputs.tf`      | Public IP, DNS name, name servers.                                     |
+| `backend-configs/prod.hcl.example` | Template for the operator's gitignored `prod.hcl`.    |
+| `aws-inventory.json` | Local-only AWS-state snapshot (gitignored). Generated by `scripts/aws/inventory.sh`. |
+
+## Local state hygiene
+
+- `.terraform/` — gitignored.
+- `terraform.tfstate*` — gitignored (and not relevant locally; state lives in S3).
+- `terraform.auto.tfvars` — gitignored. Only `terraform.auto.tfvars.example` is committed.
+- `.terraform.lock.hcl` — committed.
+- `aws-inventory.json` — gitignored. Local-only output of `scripts/aws/inventory.sh`.

--- a/infra/backend-configs/prod.hcl.example
+++ b/infra/backend-configs/prod.hcl.example
@@ -1,0 +1,26 @@
+# Backend configuration template for the prod (single) environment.
+#
+# The real prod.hcl is gitignored because the bucket / table / profile values are
+# operator-specific — they identify your own AWS state backend and your local AWS CLI
+# profile. Forks need their own.
+#
+# First-run setup:
+#
+#   cp backend-configs/prod.hcl.example backend-configs/prod.hcl
+#   $EDITOR backend-configs/prod.hcl
+#   terraform init -backend-config=backend-configs/prod.hcl
+#
+# Where to get the values:
+#
+#   bucket          → `terraform output state_bucket_name` in infra/bootstrap/
+#   dynamodb_table  → `terraform output lock_table_name`   in infra/bootstrap/
+#   region          → `terraform output region`            in infra/bootstrap/
+#   profile         → the AWS CLI profile name from `aws configure sso`
+#                     (matches MC_AWS_PROFILE in your .env)
+
+bucket         = "<bootstrap-state-bucket-name>"
+key            = "infra/prod/terraform.tfstate"
+region         = "us-east-1"
+dynamodb_table = "<bootstrap-lock-table-name>"
+encrypt        = true
+profile        = "<aws-cli-profile-name>"

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.44.0"
+  constraints = "~> 6.44.0"
+  hashes = [
+    "h1:+xHWvYNFliL9ukFNIPBdqmOQ15Jtw41TN3Qv0CPxi+g=",
+    "zh:0462747d28f6dcd7b1b723bea9da1600526b7cdcf929ed4be54352d74b0746e6",
+    "zh:0c9b7e7b04050360f609ff5700d8a76227fb4ea84dac92b844d82a2013706705",
+    "zh:2877a6854edf237f9d6c66dc928294cbbcf29d3f52577fb8f232d0cfd11d5c0d",
+    "zh:3347b82e222bbfad326b79c408e53a9252b80c6c762f4dd4f4617583394f0a4e",
+    "zh:33997dbe611b5abf49c87a31f29d8f797c97421f67b71fec8aa688799511b758",
+    "zh:5d5c37375c5e776e6e8f95fb8cbd8009258618b9f51c55551a18adc09ef5814a",
+    "zh:67d6bd61c52ca5f4c37c96a76f6820c9f1902e4b83f89faddf9fd7f17ba0b160",
+    "zh:739588639fa30db7084d6939c2eb9b4dd2d7f58dbb5d5b3b2c4bda2a35dcf521",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a953797142df4245bd8f456b9e78690f501a0fff2f58552db4eb2da409cd99e9",
+    "zh:aeb8d616dd34a9f1c5048ed4cdd6d7692db93cd33a468872618d4cd38c4784aa",
+    "zh:dc8420556aca50658247b097de6734259fc3a6012ff1cf96612fca10b3982f9d",
+    "zh:f9083d6d9fb9cbdcd91e38c92f96e67223ecc7ce6d0986bd5eb8e6d52e9aa02b",
+    "zh:f9418aa1e4d29f9026aa6f521e97d085e000902ea929debbbef61135185e3ad4",
+    "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
+  ]
+}

--- a/infra/bootstrap/README.md
+++ b/infra/bootstrap/README.md
@@ -1,0 +1,127 @@
+# `infra/bootstrap/` — Terraform remote-state backend
+
+This layer creates the S3 bucket and DynamoDB lock table that hold the **main** layer's remote state. It is its own
+Terraform configuration with **no `backend` block**: bootstrap state lives on the operator's laptop. That solves the
+chicken-and-egg problem — the layer creates the very bucket the main layer would otherwise need before `terraform
+init` could even run.
+
+This layer changes very rarely. Re-running it after the initial apply is unusual; recovery from a lost laptop is the
+common reason (
+see [Recovery: rebuild local state from live AWS resources](#recovery-rebuild-local-state-from-live-aws-resources)).
+
+## Operator vs. agent split
+
+| Command                           | Owner    | Notes                                                  |
+|-----------------------------------|----------|--------------------------------------------------------|
+| First `terraform init`            | Operator | Operator runs this so they can see how AWS init works. |
+| Subsequent `terraform init`       | Agent    | Re-init after lock-file or backend-config edits.       |
+| `terraform validate` / `fmt`      | Agent    | Routine authoring.                                     |
+| `terraform plan`                  | Agent    | Required before any apply.                             |
+| `terraform import`                | Agent    | n/a here — bootstrap has no imported resources.        |
+| `terraform state rm` / `state mv` | Agent    | For fixing botched imports.                            |
+| `terraform apply` / `destroy`     | Operator | Cloud-resource mutation; never run by the agent.       |
+
+The agent will stop at every operator-owned step.
+
+## First-run workflow
+
+Prerequisites:
+
+- AWS CLI v2.22+ on `PATH` and `MC_AWS_PROFILE` populated in `.env` (see `docs/aws-auth-setup.md`).
+- `./scripts/aws/verify-credentials.sh` exits clean.
+- Terraform 1.5.0+ on `PATH`.
+
+Steps:
+
+1. **Operator** — copy the tfvars template and pick a globally unique S3 bucket name:
+
+    ```bash
+    cd infra/bootstrap
+    cp terraform.auto.tfvars.example terraform.auto.tfvars
+    $EDITOR terraform.auto.tfvars   # set state_bucket_name to e.g. mc-aws-tfstate-<short-random>
+    ```
+
+   The `terraform.auto.tfvars` file is gitignored. The same `state_bucket_name` value will be re-used in
+   `infra/backend-configs/prod.hcl` for the main layer.
+
+2. **Operator** — run the first `terraform init`:
+
+    ```bash
+    terraform init
+    ```
+
+3. **Agent** — runs `terraform plan` and confirms the plan creates exactly one S3 bucket (with versioning, public
+   access blocked, AES256 encryption) and one DynamoDB table (with `LockID` partition key) and nothing else.
+
+4. **Operator** — runs `terraform apply` after reviewing the plan.
+
+5. **Operator** (or agent on their behalf) — copies `infra/backend-configs/prod.hcl.example` to
+   `infra/backend-configs/prod.hcl` (gitignored) and fills in the three outputs above. See `infra/README.md` for the
+   first-run workflow that follows.
+
+## What gets created
+
+- **S3 bucket** holding `terraform.tfstate` for the main layer:
+    - Versioning enabled (so a bad apply can be rolled back to a prior state object).
+    - Public access fully blocked (ACLs, bucket policies, both).
+    - Server-side encryption: SSE-S3 (AES256). KMS is a future option if a CMK ever lands in the project.
+- **DynamoDB table** for state locks:
+    - `PAY_PER_REQUEST` billing (cheapest at low volume).
+    - `LockID` partition key (string), as required by the S3 backend.
+
+## What is NOT created here
+
+- Resources for the running Minecraft server. Those live in the main `infra/` layer.
+- IAM users, roles, or permission sets. Operator access is via IAM Identity Center (see
+  `docs/aws-auth-setup.md`).
+- KMS keys. The state bucket uses SSE-S3, not SSE-KMS. Add KMS if/when a real reason emerges.
+
+## Recovery: rebuild local state from live AWS resources
+
+If `terraform.tfstate` for this layer is lost (laptop wiped, accidental `rm`, fresh clone of the repo on a new
+machine), the live AWS resources still exist — they just no longer have a Terraform record. Reconstruct local state
+**without using the AWS console**:
+
+1. Re-create the working tree:
+
+    ```bash
+    cd infra/bootstrap
+    cp terraform.auto.tfvars.example terraform.auto.tfvars
+    $EDITOR terraform.auto.tfvars   # set state_bucket_name to the existing bucket's name
+    terraform init
+    ```
+
+2. Discover the live resource names with the AWS CLI (uses `MC_AWS_PROFILE` from `.env`):
+
+    ```bash
+    aws s3api list-buckets \
+      --profile "$MC_AWS_PROFILE" \
+      --query 'Buckets[?contains(Name, `tfstate`)].Name' \
+      --output text
+
+    aws dynamodb list-tables \
+      --profile "$MC_AWS_PROFILE" \
+      --region "$(aws configure get region --profile "$MC_AWS_PROFILE")" \
+      --query 'TableNames[?contains(@, `tfstate-locks`)]' \
+      --output text
+    ```
+
+3. Import each resource. The bucket import key is the bucket name; the table import key is the table name:
+
+    ```bash
+    terraform import aws_s3_bucket.tfstate <bucket-name>
+    terraform import aws_s3_bucket_versioning.tfstate <bucket-name>
+    terraform import aws_s3_bucket_public_access_block.tfstate <bucket-name>
+    terraform import aws_s3_bucket_server_side_encryption_configuration.tfstate <bucket-name>
+    terraform import aws_dynamodb_table.tfstate_locks <table-name>
+    ```
+
+4. Run `terraform plan`. It must report **zero changes**. If it does not, the live resource has drifted from the
+   committed `.tf` files; reconcile by adjusting the `.tf` (preferred) or planning a one-shot apply (operator).
+
+## Local state hygiene
+
+- `.terraform/` (provider plugins, modules cache) — gitignored.
+- `terraform.tfstate*` — gitignored (state files contain resource metadata and may contain secrets).
+- `terraform.auto.tfvars` (real values) — gitignored. Only `terraform.auto.tfvars.example` is committed.
+- `.terraform.lock.hcl` — committed. Pinning provider hashes is a security and reproducibility concern.

--- a/infra/bootstrap/dynamodb.tf
+++ b/infra/bootstrap/dynamodb.tf
@@ -1,0 +1,12 @@
+resource "aws_dynamodb_table" "tfstate_locks" {
+  name         = var.lock_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = var.tags
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "state_bucket_name" {
+  description = "S3 bucket holding Terraform remote state for the main layer. Paste into infra/backend-configs/prod.hcl as `bucket`."
+  value       = aws_s3_bucket.tfstate.bucket
+}
+
+output "lock_table_name" {
+  description = "DynamoDB table for Terraform state locks. Paste into infra/backend-configs/prod.hcl as `dynamodb_table`."
+  value       = aws_dynamodb_table.tfstate_locks.name
+}
+
+output "region" {
+  description = "AWS region the state bucket and lock table were created in. Paste into infra/backend-configs/prod.hcl as `region`."
+  value       = var.region
+}

--- a/infra/bootstrap/providers.tf
+++ b/infra/bootstrap/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.44.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}

--- a/infra/bootstrap/s3.tf
+++ b/infra/bootstrap/s3.tf
@@ -1,0 +1,31 @@
+resource "aws_s3_bucket" "tfstate" {
+  bucket = var.state_bucket_name
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_versioning" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "tfstate" {
+  bucket = aws_s3_bucket.tfstate.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/infra/bootstrap/terraform.auto.tfvars.example
+++ b/infra/bootstrap/terraform.auto.tfvars.example
@@ -1,0 +1,14 @@
+# Copy this file to terraform.auto.tfvars and fill in real values. terraform.auto.tfvars is gitignored.
+#
+#   cp terraform.auto.tfvars.example terraform.auto.tfvars
+#   $EDITOR terraform.auto.tfvars
+
+# Globally unique S3 bucket name for the remote-state backend. Suggested form:
+#   mc-aws-tfstate-<short-random-suffix>
+# The same value must appear in infra/backend-configs/prod.hcl for the main layer.
+state_bucket_name = "mc-aws-tfstate-CHANGEME"
+
+# Optional overrides — defaults match the project's IdC profile and region.
+# region          = "us-east-1"
+# aws_profile     = "mc-aws"
+# lock_table_name = "mc-aws-tfstate-locks"

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,41 @@
+variable "region" {
+  description = "AWS region for the remote-state backend resources. Must match the region the main infra/ layer targets."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile name configured via IAM Identity Center (matches MC_AWS_PROFILE in .env)."
+  type        = string
+  default     = "mc-aws"
+}
+
+variable "state_bucket_name" {
+  description = <<-EOT
+    Globally unique S3 bucket name for Terraform remote state. S3 bucket names share a global namespace,
+    so pick something that is unlikely to collide (e.g. "mc-aws-tfstate-<random-suffix>"). The same value
+    must appear in infra/backend-configs/prod.hcl for the main layer.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$", var.state_bucket_name))
+    error_message = "state_bucket_name must be a valid S3 bucket name (lowercase, 3-63 chars, no underscores)."
+  }
+}
+
+variable "lock_table_name" {
+  description = "DynamoDB table name for Terraform state locks. Account-and-region-scoped, so collisions are local."
+  type        = string
+  default     = "mc-aws-tfstate-locks"
+}
+
+variable "tags" {
+  description = "Tags applied to every resource the bootstrap layer manages."
+  type        = map(string)
+  default = {
+    Project   = "azure-hosted-minecraft"
+    Component = "tf-bootstrap"
+    ManagedBy = "terraform"
+  }
+}

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -1,0 +1,16 @@
+# The bytehorizonforge.com hosted zone pre-existed this project and hosts records for
+# unrelated concerns (an Azure M365 email setup under auth.*). It is therefore looked up
+# via a data source rather than imported as a resource — this Terraform does not own the
+# zone, only the single record that points the Minecraft DNS at the LightSail static IP.
+
+data "aws_route53_zone" "bytehorizonforge" {
+  name = "bytehorizonforge.com"
+}
+
+resource "aws_route53_record" "mc" {
+  zone_id = data.aws_route53_zone.bytehorizonforge.zone_id
+  name    = "mc.bytehorizonforge.com"
+  type    = "A"
+  ttl     = 300
+  records = [aws_lightsail_static_ip.mcserver.ip_address]
+}

--- a/infra/lightsail.tf
+++ b/infra/lightsail.tf
@@ -1,0 +1,56 @@
+resource "aws_lightsail_instance" "mcserver" {
+  name              = "mcserver-prod"
+  availability_zone = "us-east-1a"
+  blueprint_id      = "ubuntu_22_04"
+  bundle_id         = "large_3_0"
+  key_pair_name     = "ssh-mcserver"
+  ip_address_type   = "dualstack"
+
+  add_on {
+    type          = "AutoSnapshot"
+    snapshot_time = "11:00"
+    status        = "Enabled"
+  }
+}
+
+resource "aws_lightsail_instance_public_ports" "mcserver" {
+  instance_name = aws_lightsail_instance.mcserver.name
+
+  port_info {
+    protocol   = "tcp"
+    from_port  = 80
+    to_port    = 80
+    ipv6_cidrs = ["::/0"]
+  }
+
+  port_info {
+    protocol   = "tcp"
+    from_port  = 25565
+    to_port    = 25565
+    cidrs      = ["0.0.0.0/0"]
+    ipv6_cidrs = ["::/0"]
+  }
+
+  port_info {
+    protocol  = "udp"
+    from_port = 19132
+    to_port   = 19132
+    cidrs     = ["0.0.0.0/0"]
+  }
+
+  port_info {
+    protocol   = "tcp"
+    from_port  = 19132
+    to_port    = 19132
+    ipv6_cidrs = ["::/0"]
+  }
+
+  port_info {
+    protocol          = "tcp"
+    from_port         = 22
+    to_port           = 22
+    cidrs             = ["198.148.30.0/32"]
+    ipv6_cidrs        = ["::/0"]
+    cidr_list_aliases = ["lightsail-connect"]
+  }
+}

--- a/infra/networking.tf
+++ b/infra/networking.tf
@@ -1,0 +1,8 @@
+resource "aws_lightsail_static_ip" "mcserver" {
+  name = "ip-mcserver-prod"
+}
+
+resource "aws_lightsail_static_ip_attachment" "mcserver" {
+  static_ip_name = aws_lightsail_static_ip.mcserver.name
+  instance_name  = aws_lightsail_instance.mcserver.name
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "mcserver_public_ip" {
+  description = "Static IPv4 address attached to the Minecraft server."
+  value       = aws_lightsail_static_ip.mcserver.ip_address
+}
+
+output "mcserver_dns_name" {
+  description = "Public DNS name players connect to (Java edition)."
+  value       = aws_route53_record.mc.fqdn
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    # All values supplied via -backend-config=backend-configs/prod.hcl on `terraform init`.
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.44.0"
+    }
+  }
+}
+
+provider "aws" {
+  region  = var.region
+  profile = var.aws_profile
+}

--- a/infra/storage.tf
+++ b/infra/storage.tf
@@ -1,0 +1,11 @@
+resource "aws_lightsail_disk" "mcserver_data" {
+  name              = "disk-mcserver-prod"
+  size_in_gb        = 128
+  availability_zone = "us-east-1a"
+}
+
+resource "aws_lightsail_disk_attachment" "mcserver_data" {
+  disk_name     = aws_lightsail_disk.mcserver_data.name
+  instance_name = aws_lightsail_instance.mcserver.name
+  disk_path     = "/dev/xvdf"
+}

--- a/infra/terraform.auto.tfvars.example
+++ b/infra/terraform.auto.tfvars.example
@@ -1,0 +1,10 @@
+# Copy to terraform.auto.tfvars and override values as needed. terraform.auto.tfvars is gitignored.
+#
+#   cp terraform.auto.tfvars.example terraform.auto.tfvars
+#   $EDITOR terraform.auto.tfvars
+#
+# Defaults match the project's IdC profile and us-east-1 region. Override only if your
+# .env points at a different profile.
+#
+# region      = "us-east-1"
+# aws_profile = "mc-aws"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,11 @@
+variable "region" {
+  description = "AWS region for the LightSail deployment. Must match the bootstrap layer's region."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile name configured via IAM Identity Center (matches MC_AWS_PROFILE in .env)."
+  type        = string
+  default     = "mc-aws"
+}

--- a/scripts/aws/inventory.sh
+++ b/scripts/aws/inventory.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+#
+# Inventory every AWS resource the LightSail Minecraft deployment depends on.
+#
+# Used during the issue #4 reverse-engineering to drive `terraform import`
+# decisions, and re-run later as a drift-detection cross-check against
+# `terraform plan`. Output is a structured JSON snapshot ordered for stable
+# diff results across runs.
+#
+# Output is gitignored. Even with the AWS account ID redacted, the snapshot
+# pulls in cross-account bucket names, DNS records for unrelated domains,
+# IAM usernames, and other operator-specific data — too much to safely
+# commit to a public repo. Re-runs overwrite the same file; for drift
+# detection keep a local baseline copy and `diff` against it manually.
+#
+# Usage:
+#   scripts/aws/inventory.sh [output-path]
+#
+# Env / .env:
+#   MC_AWS_PROFILE  — AWS CLI profile from `aws configure sso`. Required.
+
+set -euo pipefail
+
+readonly DEFAULT_OUTPUT="infra/aws-inventory.json"
+readonly REDACTED_PLACEHOLDER="<account-id>"
+
+err() {
+  printf 'inventory: %s\n' "$*" >&2
+}
+
+script_dir() {
+  cd "$(dirname "$0")" && pwd
+}
+
+repo_root() {
+  cd "$(script_dir)/../.." && pwd
+}
+
+require_cmd() {
+  local cmd=$1
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    err "$cmd not found on PATH."
+    exit 1
+  fi
+}
+
+resolve_profile() {
+  if [ -n "${MC_AWS_PROFILE:-}" ]; then
+    printf '%s' "$MC_AWS_PROFILE"
+    return 0
+  fi
+
+  local env_file
+  env_file="$(repo_root)/.env"
+  if [ -f "$env_file" ]; then
+    local from_env
+    from_env=$(grep -E '^MC_AWS_PROFILE=' "$env_file" | head -n1 | cut -d= -f2-)
+    from_env=${from_env%\"}
+    from_env=${from_env#\"}
+    from_env=${from_env%\'}
+    from_env=${from_env#\'}
+    if [ -n "$from_env" ]; then
+      printf '%s' "$from_env"
+      return 0
+    fi
+  fi
+
+  err "MC_AWS_PROFILE is not set in env or .env."
+  err "Recover with:"
+  err "  cp .env.example .env && \$EDITOR .env"
+  exit 1
+}
+
+resolve_region() {
+  local profile=$1 region
+  region=$(aws configure get region --profile "$profile" 2>/dev/null || true)
+  if [ -z "$region" ]; then
+    err "Profile '$profile' has no region set in ~/.aws/config."
+    err "Run: aws configure sso  (and re-enter '$profile' as the profile name)."
+    exit 1
+  fi
+  printf '%s' "$region"
+}
+
+resolve_account_id() {
+  local profile=$1 account
+  account=$(aws sts get-caller-identity --profile "$profile" --query 'Account' --output text 2>/dev/null || true)
+  if [ -z "$account" ] || [ "$account" = "None" ]; then
+    err "aws sts get-caller-identity failed for profile '$profile'."
+    err "If the SSO token is expired, recover with:"
+    err "  aws sso login --profile $profile"
+    exit 1
+  fi
+  printf '%s' "$account"
+}
+
+# Run an aws command and return its JSON output, defaulting to {} on a permission error
+# so a missing-service or no-permission case doesn't kill the whole inventory.
+fetch_json() {
+  local description=$1
+  shift
+  local out
+  if ! out=$(aws "$@" --output json 2>&1); then
+    err "warning: '$description' failed; recording empty object. Detail:"
+    err "  $(printf '%s' "$out" | head -n1)"
+    printf '%s' '{}'
+    return 0
+  fi
+  printf '%s' "$out"
+}
+
+main() {
+  require_cmd aws
+  require_cmd jq
+
+  local profile region account_id
+  profile=$(resolve_profile)
+  region=$(resolve_region "$profile")
+  account_id=$(resolve_account_id "$profile")
+
+  local output_path
+  output_path=${1:-$DEFAULT_OUTPUT}
+  if [ "${output_path#/}" = "$output_path" ]; then
+    output_path="$(repo_root)/$output_path"
+  fi
+
+  err "profile=$profile region=$region account=${account_id:0:4}…"
+  err "output=$output_path"
+  err "running AWS API queries (this can take ~10–20s)..."
+
+  local ls_instances ls_disks ls_disk_snapshots ls_instance_snapshots
+  local ls_static_ips ls_key_pairs ls_domains ls_load_balancers ls_relational_databases
+  ls_instances=$(fetch_json "lightsail get-instances" --profile "$profile" lightsail get-instances)
+  ls_disks=$(fetch_json "lightsail get-disks" --profile "$profile" lightsail get-disks)
+  ls_disk_snapshots=$(fetch_json "lightsail get-disk-snapshots" --profile "$profile" lightsail get-disk-snapshots)
+  ls_instance_snapshots=$(fetch_json "lightsail get-instance-snapshots" --profile "$profile" lightsail get-instance-snapshots)
+  ls_static_ips=$(fetch_json "lightsail get-static-ips" --profile "$profile" lightsail get-static-ips)
+  ls_key_pairs=$(fetch_json "lightsail get-key-pairs" --profile "$profile" lightsail get-key-pairs)
+  ls_domains=$(fetch_json "lightsail get-domains" --profile "$profile" lightsail get-domains)
+  ls_load_balancers=$(fetch_json "lightsail get-load-balancers" --profile "$profile" lightsail get-load-balancers)
+  ls_relational_databases=$(fetch_json "lightsail get-relational-databases" \
+                                       --profile "$profile" lightsail get-relational-databases)
+
+  # Per-instance port states (firewall rules) keyed by instance name.
+  local instance_names ls_port_states
+  instance_names=$(printf '%s' "$ls_instances" | jq -r '(.instances // [])[].name')
+  ls_port_states='{}'
+  if [ -n "$instance_names" ]; then
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      local ports
+      ports=$(fetch_json "lightsail get-instance-port-states ($name)" \
+                         --profile "$profile" lightsail get-instance-port-states --instance-name "$name")
+      ls_port_states=$(printf '%s' "$ls_port_states" | \
+                       jq --arg n "$name" --argjson p "$ports" '. + {($n): $p}')
+    done <<<"$instance_names"
+  fi
+
+  # Route 53 (global service — no region argument).
+  local r53_zones
+  r53_zones=$(fetch_json "route53 list-hosted-zones" --profile "$profile" route53 list-hosted-zones)
+
+  local zone_ids r53_records
+  zone_ids=$(printf '%s' "$r53_zones" | jq -r '(.HostedZones // [])[].Id')
+  r53_records='{}'
+  if [ -n "$zone_ids" ]; then
+    while IFS= read -r zid; do
+      [ -z "$zid" ] && continue
+      local short_id recs
+      short_id=${zid##*/}
+      recs=$(fetch_json "route53 list-resource-record-sets ($short_id)" \
+                       --profile "$profile" route53 list-resource-record-sets --hosted-zone-id "$zid")
+      r53_records=$(printf '%s' "$r53_records" | \
+                    jq --arg id "$short_id" --argjson r "$recs" '. + {($id): $r}')
+    done <<<"$zone_ids"
+  fi
+
+  # IAM is global — list metadata only, never policy documents (those can leak resource ARNs).
+  local iam_users iam_roles iam_policies
+  iam_users=$(fetch_json "iam list-users" --profile "$profile" iam list-users)
+  iam_roles=$(fetch_json "iam list-roles" --profile "$profile" iam list-roles)
+  iam_policies=$(fetch_json "iam list-policies (Local scope)" \
+                            --profile "$profile" iam list-policies --scope Local)
+
+  local s3_buckets
+  s3_buckets=$(fetch_json "s3api list-buckets" --profile "$profile" s3api list-buckets)
+
+  local snapshot
+  snapshot=$(jq -n \
+    --arg profile "$profile" \
+    --arg region "$region" \
+    --argjson ls_instances "$ls_instances" \
+    --argjson ls_disks "$ls_disks" \
+    --argjson ls_disk_snapshots "$ls_disk_snapshots" \
+    --argjson ls_instance_snapshots "$ls_instance_snapshots" \
+    --argjson ls_static_ips "$ls_static_ips" \
+    --argjson ls_key_pairs "$ls_key_pairs" \
+    --argjson ls_domains "$ls_domains" \
+    --argjson ls_load_balancers "$ls_load_balancers" \
+    --argjson ls_relational_databases "$ls_relational_databases" \
+    --argjson ls_port_states "$ls_port_states" \
+    --argjson r53_zones "$r53_zones" \
+    --argjson r53_records "$r53_records" \
+    --argjson iam_users "$iam_users" \
+    --argjson iam_roles "$iam_roles" \
+    --argjson iam_policies "$iam_policies" \
+    --argjson s3_buckets "$s3_buckets" \
+    '{
+       profile: $profile,
+       region: $region,
+       lightsail: {
+         instances: $ls_instances,
+         disks: $ls_disks,
+         disk_snapshots: $ls_disk_snapshots,
+         instance_snapshots: $ls_instance_snapshots,
+         static_ips: $ls_static_ips,
+         key_pairs: $ls_key_pairs,
+         domains: $ls_domains,
+         load_balancers: $ls_load_balancers,
+         relational_databases: $ls_relational_databases,
+         instance_port_states: $ls_port_states
+       },
+       route53: {
+         hosted_zones: $r53_zones,
+         records: $r53_records
+       },
+       iam: {
+         users: $iam_users,
+         roles: $iam_roles,
+         customer_managed_policies: $iam_policies
+       },
+       s3: {
+         buckets: $s3_buckets
+       }
+     }')
+
+  # Redact the AWS account ID from every ARN / UserId before writing.
+  # The account ID is a 12-digit string; sed's literal-string replacement is safe
+  # against false positives at this width.
+  printf '%s' "$snapshot" | jq -S '.' | sed "s/${account_id}/${REDACTED_PLACEHOLDER}/g" > "$output_path"
+
+  err "wrote $(wc -c <"$output_path" | tr -d ' ') bytes to $output_path"
+  err "snapshot is gitignored — keep a baseline copy locally if you want drift detection"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Two-layer Terraform stack: `infra/bootstrap/` (file-per-concern S3 + DynamoDB lock backend; local state) + `infra/`
  (file-per-concern main layer; remote state via S3 + DynamoDB).
- 7 live AWS resources imported (LightSail instance, data disk + attachment, static IP + attachment,
  `mc.bytehorizonforge.com` A record). `aws_lightsail_instance_public_ports.mcserver` materialized via apply
  (cannot be imported — provider gap; documented). The `bytehorizonforge.com.` Route 53 zone is read via a `data`
  source (mixed-purpose zone — also hosts unrelated Azure M365 records — so this stack uses but does not own it).
- `scripts/aws/inventory.sh` (shellcheck-clean, idempotent, redacts AWS account ID) for ad-hoc inventory; output is
  gitignored because even with the account ID redacted, the snapshot pulls in cross-account bucket names,
  personal-domain DNS records, and IAM usernames that don't belong in a public repo.
- Backend config (`infra/backend-configs/prod.hcl`) is gitignored; the committed `prod.hcl.example` template is what
  forks fill in. Operator-specific bucket / table / profile names stay off the public internet.

Closes #4. Follow-up filed as #8 (firewall tightening — SSH IPv6 ::/0, vestigial 19132/tcp, port 80 investigation).

## Final `terraform plan` output (zero-change acceptance evidence)

```
aws_lightsail_disk.mcserver_data: Refreshing state... [id=disk-mcserver-prod]
data.aws_route53_zone.bytehorizonforge: Reading...
aws_lightsail_static_ip.mcserver: Refreshing state... [id=ip-mcserver-prod]
aws_lightsail_instance.mcserver: Refreshing state... [id=mcserver-prod]
data.aws_route53_zone.bytehorizonforge: Read complete after 0s [id=Z09024551TI8L9018Y7IE]
aws_route53_record.mc: Refreshing state... [id=Z09024551TI8L9018Y7IE_mc.bytehorizonforge.com_A]
aws_lightsail_static_ip_attachment.mcserver: Refreshing state... [id=ip-mcserver-prod]
aws_lightsail_disk_attachment.mcserver_data: Refreshing state... [id=disk-mcserver-prod,mcserver-prod]
aws_lightsail_instance_public_ports.mcserver: Refreshing state... [id=mcserver-prod-4228023813]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration
and found no differences, so no changes are needed.
```

## Test plan

- [x] `terraform fmt -recursive` clean in both `infra/bootstrap/` and `infra/`.
- [x] `shellcheck scripts/aws/inventory.sh` clean.
- [x] Bootstrap layer applied successfully (S3 bucket + DynamoDB lock table created).
- [x] Main layer initialized with `-backend-config=backend-configs/prod.hcl`; remote state in place.
- [x] All 7 importable resources imported; `terraform plan` reports `No changes` (output above).
- [x] `aws_lightsail_instance_public_ports.mcserver` apply confirmed as no-op AWS-side (rules already match live
      state); player connectivity not interrupted.
- [x] `infra/backend-configs/prod.hcl` (real values), `infra/aws-inventory.json` (operator-specific data), and
      `*.auto.tfvars` files all confirmed gitignored.
- [ ] Reviewer: read `infra/README.md` "Resources that can't be imported" + "Why the bytehorizonforge zone is a data
      source" sections to validate scope decisions.
- [ ] Reviewer: confirm no AWS account IDs, secrets, or personal data committed (`git log -p HEAD~..HEAD` or PR diff
      scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
