### PR TITLE
chore: rename repo references and expand root README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project context
+
+The live deployment is on **AWS LightSail**. An earlier Azure backend (PR #2) was scrapped and the repo was reset
+on 2026-05-09 to reverse-engineer a hand-built LightSail Minecraft deployment into Terraform (issue #4, merged in
+PR #9). The repo was originally named `azure-hosted-minecraft` and renamed to `aws-hosted-minecraft` on 2026-05-09;
+historical commits, PR titles, and issue bodies may still mention Azure or the old name.
+
+The eventual goal is idempotent scripts that can rebuild or repair the live server, plus a Python nightly updater
+for Paper / Geyser / Floodgate version bumps. The updater is deliberately not designed yet — it waits on issue #4
+(closed — Terraform import) and issue #5 (open — server-state capture from the live host), so its requirements
+are shaped by what those uncover.
+
+## Architecture
+
+The Terraform stack lives in two layers under `infra/`:
+
+- **`infra/bootstrap/`** — provisions the S3 bucket + DynamoDB lock table that hold the main layer's remote state.
+  Has **no `backend` block**; its own state lives on the operator's laptop. This solves the chicken-and-egg of
+  bootstrapping its own state backend. Re-running this layer is rare (recovery scenarios only — see its README).
+- **`infra/`** — the main layer. Manages the live LightSail Minecraft deployment via an S3 backend whose values
+  come from `backend-configs/prod.hcl` (gitignored; the operator copies `prod.hcl.example` and fills in bucket /
+  lock-table / profile from the bootstrap layer's outputs).
+
+The main layer was authored by importing existing AWS resources, so `terraform plan` is zero changes for everything
+it manages. See `infra/README.md` for the full import map and the deliberately-not-imported resources:
+`aws_lightsail_instance_public_ports.mcserver` (provider gap — applied as a no-op to enter state), the
+`ssh-mcserver` key pair (the AWS provider docs explicitly forbid importing), LightSail snapshots (no provider
+resource exists), and the `bytehorizonforge.com` Route 53 zone — that one is a `data` source on purpose because it
+pre-existed this project and hosts unrelated Azure M365 records (`auth.bytehorizonforge.com`).
+
+### File-per-concern Terraform layout
+
+No `main.tf` — ever. Resources are split by domain: `providers.tf`, `variables.tf`, `outputs.tf`, plus per-domain
+files (`lightsail.tf`, `networking.tf`, `storage.tf`, `dns.tf`). `infra/bootstrap/` follows the same pattern
+(`s3.tf`, `dynamodb.tf`). Modules under `infra/modules/<name>/` are acceptable only when a real reuse boundary
+appears — do not pre-extract speculatively. If a future PR proposes a `main.tf` or speculative module, push back.
+
+## Operator vs. agent split (Terraform)
+
+The agent runs routine, low-risk Terraform commands. The operator runs anything that mutates AWS or initializes a
+layer for the first time. **The agent must stop at every operator-owned step**, even if the plan looks safe.
+
+| Command                           | Owner    |
+|-----------------------------------|----------|
+| First `terraform init` per layer  | Operator |
+| Subsequent `terraform init`       | Agent    |
+| `terraform validate` / `fmt`      | Agent    |
+| `terraform plan`                  | Agent    |
+| `terraform import`                | Agent    |
+| `terraform state rm` / `state mv` | Agent    |
+| `terraform apply` / `destroy`     | Operator |
+
+## AWS authentication
+
+- Account `444672861827`, region `us-east-1`, profile `mc-aws` (IAM Identity Center, `AdministratorAccess`
+  permission set). Pass `--profile mc-aws` or set `AWS_PROFILE=mc-aws` for every `aws` / `terraform` invocation.
+- The cached SSO token at `~/.aws/sso/cache/` typically expires every 8–12 hours. Recovery: `aws sso login
+  --profile mc-aws`.
+- `MC_AWS_PROFILE=mc-aws` lives in the gitignored `.env`. See `docs/aws-auth-setup.md` for the full IdC walkthrough
+  (Checkpoints A–F); `.env.example` lists every required key (also `MC_SSH_HOST`, `MC_SSH_USER`, `MC_SSH_KEY` for
+  reaching the live host).
+
+## Common commands
+
+```bash
+# Verify AWS CLI auth (read-only; run before anything that touches AWS).
+./scripts/aws/verify-credentials.sh
+
+# Snapshot every AWS resource the deployment depends on (drift detection).
+./scripts/aws/inventory.sh   # writes infra/aws-inventory.json (gitignored)
+
+# Bootstrap layer (rare — only on first setup or laptop recovery).
+cd infra/bootstrap && terraform fmt -recursive && terraform validate && terraform plan
+
+# Main layer.
+cd infra && terraform init -backend-config=backend-configs/prod.hcl
+terraform fmt -recursive && terraform validate && terraform plan   # plan must be zero changes
+
+# Lint shell scripts (project requires shellcheck-clean).
+shellcheck scripts/aws/*.sh
+
+# Python formatter (line-length 120 from pyproject.toml). Project requires Python 3.13+.
+black .
+```
+
+There are no Python files yet — `server/` and `docs/` only contain `.gitkeep` placeholders plus the AWS auth doc.
+
+## Public-repo hygiene
+
+This is a public GitHub repo. Never commit, paste into PR descriptions, or echo to logs:
+
+- The AWS account ID (12 digits) — redact to `<account-id>` or `<redacted>`. The inventory script already redacts.
+- Real `.env` values: SSH host / user / PEM path, `MC_AWS_PROFILE` if it identifies the operator.
+- `infra/backend-configs/*.hcl` (only `*.hcl.example` is committed).
+- `infra/aws-inventory.json` (operator-specific data — cross-account bucket names, personal-domain DNS records,
+  M365 verification tokens, IAM usernames — even with the account ID redacted).
+- Anything from `~/.aws/`, including SSO start URLs.
+
+`.env`, `*.pem`, `*.tfvars`, real `*.hcl` backend configs, and the inventory snapshot are already gitignored.
+
+## Project rules
+
+Topic-specific instructions live in `.claude/rules/` and load alongside this file. They cover Terraform conventions,
+Python style, line length (120 char wrap in `.md` / `.py` / `.tf` / `.tfvars` / `.hcl` / `.yml` / `.yaml` / `.sh`),
+dependency vetting via the `vet-dependency` skill, scripted infrastructure setup (no prose-recipe operator steps —
+ship a script under `scripts/`), harness-format enforcement, external-API grounding, and skill matching on
+redirected intent. Read the relevant rule before touching the matching file type or planning operator-facing work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,8 +56,10 @@ layer for the first time. **The agent must stop at every operator-owned step**, 
 
 ## AWS authentication
 
-- Account `444672861827`, region `us-east-1`, profile `mc-aws` (IAM Identity Center, `AdministratorAccess`
-  permission set). Pass `--profile mc-aws` or set `AWS_PROFILE=mc-aws` for every `aws` / `terraform` invocation.
+- Region `us-east-1`, profile `mc-aws` (IAM Identity Center, `AdministratorAccess` permission set). Pass
+  `--profile mc-aws` or set `AWS_PROFILE=mc-aws` for every `aws` / `terraform` invocation. The account ID lives
+  in operator-local config (`.env` / SSO cache); recover it on demand via `aws sts get-caller-identity` if you
+  need it.
 - The cached SSO token at `~/.aws/sso/cache/` typically expires every 8–12 hours. Recovery: `aws sso login
   --profile mc-aws`.
 - `MC_AWS_PROFILE=mc-aws` lives in the gitignored `.env`. See `docs/aws-auth-setup.md` for the full IdC walkthrough

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
 # aws-hosted-minecraft
-AWS LightSail-hosted Minecraft server infrastructure with automated provisioning, secure networking, and lifecycle management. Designed for reproducible setups, easy updates, and low-maintenance operation using modern IaC and cloud-native practices.
+
+A personal-scale Minecraft server hosted on AWS LightSail, with infrastructure managed by Terraform and operator
+workflows captured in committed scripts and docs. Designed for reproducibility — a forked clone with a fresh AWS
+account should be able to stand up an equivalent stack from this repo plus its own secrets.
+
+## Status
+
+The repo was reset on 2026-05-09 to reverse-engineer a hand-built deployment that pre-dated source-controlled
+infrastructure. Two foundational issues drive the work:
+
+- **#4** (closed,
+  [PR #9](https://github.com/brandonavant/aws-hosted-minecraft/pull/9)) — AWS LightSail infrastructure imported
+  into Terraform. `terraform plan` is zero-changes against the live deployment.
+- **#5** (open) — capture and document the Minecraft server's on-host state (file layout, systemd service, world
+  data, Paper / Geyser / Floodgate versions) so the eventual Python updater can repair or rebuild a server from
+  scratch.
+
+Server-side bootstrap (cloud-init, plugin install, world bind-mount, systemd unit) and the nightly version-bump
+updater come after #5 closes.
+
+## What's deployed
+
+- **Compute** — AWS LightSail Ubuntu 22.04 instance (`large_3_0` bundle) in `us-east-1a`.
+- **Storage** — 128 GB LightSail data disk attached at `/dev/xvdf` for the world directory.
+- **Networking** — a static LightSail IPv4 address bound to the instance.
+- **DNS** — `mc.bytehorizonforge.com` A-record points at the static IP (Route 53).
+- **Firewall** — Java Edition (TCP 25565), Bedrock Edition (UDP 19132), HTTP (TCP 80), and SSH (TCP 22, IPv4
+  restricted to LightSail Connect's range). Open issue
+  [#8](https://github.com/brandonavant/aws-hosted-minecraft/issues/8) tracks tightening rules that the inventory
+  script flagged.
+- **Backups** — LightSail AutoSnapshot daily at 11:00 UTC.
+
+The Terraform stack covers everything in this list except the `ssh-mcserver` key pair (the AWS provider docs
+forbid importing it) and LightSail snapshots (no Terraform resource exists for this provider). See
+`infra/README.md` for the full list of deliberately-unmanaged resources and the rationale.
+
+## Repo layout
+
+| Path                | Purpose                                                                            |
+|---------------------|------------------------------------------------------------------------------------|
+| `infra/bootstrap/`  | Terraform layer that provisions the S3 + DynamoDB remote-state backend.            |
+| `infra/`            | Main Terraform layer — imports and manages the live LightSail deployment.          |
+| `scripts/aws/`      | Operator-facing AWS scripts: credential verification, drift inventory.             |
+| `docs/`             | Long-form operator walkthroughs (currently: AWS CLI auth via IAM Identity Center). |
+| `server/`           | Reserved for on-host server state and the future updater (placeholder).            |
+| `.claude/`          | Project rules and skills used by Claude Code.                                      |
+
+Per-directory READMEs in `infra/` and `infra/bootstrap/`, plus `docs/aws-auth-setup.md`, carry the detail.
+
+## Setup from scratch (forking operators)
+
+1. **AWS authentication** — follow `docs/aws-auth-setup.md` end-to-end (Checkpoints A–F). Ends with
+   `./scripts/aws/verify-credentials.sh` exiting clean.
+2. **Bootstrap layer** — `cd infra/bootstrap`, copy `terraform.auto.tfvars.example` to `terraform.auto.tfvars`,
+   pick a globally-unique S3 bucket name, then `terraform init` and `terraform apply`. See
+   `infra/bootstrap/README.md` for the full first-run workflow and a recovery path if the local state is lost.
+3. **Main layer** — `cd infra`, copy `backend-configs/prod.hcl.example` to `prod.hcl` with the bootstrap layer's
+   outputs, then `terraform init -backend-config=backend-configs/prod.hcl`. The committed `.tf` files match the
+   shape of the existing live deployment, so the import path documented in `infra/README.md` is the supported one
+   today; a clean greenfield apply has not been exercised and may surface differences that need to be reconciled.
+
+The eventual server-side install path (cloud-init / Paper / Geyser / Floodgate / systemd) is intentionally
+out-of-scope until issue #5 closes — that issue's audit dictates what the install scripts will need to reproduce.
+
+## Operating the live server
+
+- `./scripts/aws/verify-credentials.sh` — read-only AWS auth check. Run this whenever an AWS call starts failing;
+  it surfaces expired SSO tokens, missing region config, and wrong-permission-set ARNs with a copy-paste recovery
+  command.
+- `./scripts/aws/inventory.sh` — snapshot every relevant AWS resource into `infra/aws-inventory.json` (gitignored,
+  account ID redacted). Keep a local baseline copy and `diff` against future runs for drift detection on
+  resources Terraform doesn't manage (key pair, instance snapshots, unrelated records in the shared
+  `bytehorizonforge.com` zone).
+- `terraform fmt -recursive` / `terraform validate` / `terraform plan` — routine Terraform hygiene. `apply` and
+  `destroy` are operator-only.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# azure-hosted-minecraft
-Azure-hosted Minecraft server infrastructure with automated provisioning, secure networking, and lifecycle management. Designed for reproducible setups, easy updates, and low-maintenance operation using modern IaC and cloud-native practices.
+# aws-hosted-minecraft
+AWS LightSail-hosted Minecraft server infrastructure with automated provisioning, secure networking, and lifecycle management. Designed for reproducible setups, easy updates, and low-maintenance operation using modern IaC and cloud-native practices.

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -34,7 +34,7 @@ variable "tags" {
   description = "Tags applied to every resource the bootstrap layer manages."
   type        = map(string)
   default = {
-    Project   = "azure-hosted-minecraft"
+    Project   = "aws-hosted-minecraft"
     Component = "tf-bootstrap"
     ManagedBy = "terraform"
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "azure-hosted-minecraft"
+name = "aws-hosted-minecraft"
 version = "0.1.0"
-description = "A toolkit for deploying and managing Minecraft servers on Microsoft Azure."
+description = "A toolkit for deploying and managing Minecraft servers on AWS LightSail."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = []


### PR DESCRIPTION
## Summary

Documentation cleanup after renaming the GitHub repo (and local working tree) from `azure-hosted-minecraft` to
`aws-hosted-minecraft`.

**Rename references** — update the four tracked files that still embedded the old name:

- `README.md` — heading and description (rewritten in full as part of the second commit; see below).
- `pyproject.toml` — `name` and `description` fields.
- `infra/bootstrap/variables.tf` — `Project` tag default in the `tags` variable.
- `CLAUDE.md` — drops the now-obsolete "the repo name says azure" gotcha from the project-context paragraph and
  replaces it with a brief rename note so future Claude sessions can interpret old commit / PR / issue text that
  still references the previous name.

**Expand the root README** from a two-line stub into a real overview aimed at future Brandon, forking operators,
and casual visitors:

- Project status and the two foundational issues driving the reverse-engineering work (#4 closed, #5 open).
- What's actually deployed — compute (LightSail Ubuntu 22.04 `large_3_0`), storage (128 GB attached disk),
  networking (static IPv4), DNS (`mc.bytehorizonforge.com`), firewall (Java / Bedrock / HTTP / SSH ports),
  AutoSnapshot schedule — and what Terraform deliberately doesn't manage (key pair, snapshots).
- Repo-layout table.
- First-run setup walkthrough that points at the per-directory READMEs and `docs/aws-auth-setup.md` instead of
  duplicating their content.
- Day-to-day operating commands (`verify-credentials.sh`, `inventory.sh`, Terraform hygiene).

The README is grounded in committed code only — no operator-specific values, no account ID, no `.env` content.

GitHub redirects the old `azure-hosted-minecraft` HTTPS URL, so existing clones and CI configurations keep working
without intervention.

## Heads-up: bootstrap tag drift

The `Project` tag on the live S3 state bucket and DynamoDB lock table is still `"azure-hosted-minecraft"`. After
this PR merges, the next `terraform plan` in `infra/bootstrap/` will show a tag-only drift on those two resources,
and an operator-run `terraform apply` is required to push the new tag value. The plan is two `update in-place`
changes touching `tags["Project"]` only — no other side effects, no replacement, no downtime risk for the live
Minecraft server (which lives in the main `infra/` layer, not bootstrap).

## Operator follow-up (out of scope for this PR)

Local clones still point `origin` at the old GitHub URL. GitHub redirects, but for hygiene each operator should
update their own remote:

```bash
git remote set-url origin https://github.com/brandonavant/aws-hosted-minecraft.git
```

This is operator-local and not a tracked change.

## Test plan

- [x] Repo-wide `grep -rn "azure-hosted-minecraft"` returns only the deliberate historical reference inside
  `CLAUDE.md`.
- [x] `terraform fmt -check` clean for `infra/bootstrap/variables.tf`.
- [x] CLAUDE.md and README.md both wrap under 120 chars per the project's line-length rule.
- [x] README cross-references (file paths, issue / PR numbers, port numbers, instance bundle / disk size) verified
  against the committed Terraform and PR history before writing.
- [ ] Reviewer: confirm the CLAUDE.md project-context edit reads correctly to a future Claude session that has no
  knowledge of the rename.
- [ ] Reviewer: skim README "What's deployed" and "Setup from scratch" sections for any over-claim or stale fact.
- [ ] Reviewer (operator): plan + apply `infra/bootstrap/` after merge to pick up the new `Project` tag value on
  the live state-backend resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
