### PR TITLE
feat: nightly Geyser/Floodgate/Paper/ViaVersion updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ infrastructure. Two foundational issues drive the work:
   into Terraform. `terraform plan` is zero-changes against the live deployment.
 - **#5** (closed) — initial state-capture effort. Superseded by #11 once it became clear the deliverable should be
   an executable provisioner, not a captured runbook.
-- **#11** (open) — idempotent Python provisioner under `scripts/server/install.py` that takes a fresh LightSail
+- **#11** (closed) — idempotent Python provisioner under `scripts/server/install.py` that takes a fresh LightSail
   Ubuntu 22.04 instance with the data volume re-attached and produces a running Paper + Geyser + Floodgate +
   ViaVersion crossplay server.
-
-The nightly version-bump updater is a separate, later issue that will consume the same APIs the provisioner
-already speaks (PaperMC Fill v3, Geyser/Floodgate v2, Hangar).
+- **#14** (in flight) — idempotent Python updater under `scripts/server/update.py`, run on a systemd timer, that
+  keeps Geyser / Floodgate / Paper / ViaVersion current so Bedrock clients stay connectable when Mojang ships a
+  protocol bump.
 
 ## What's deployed
 
@@ -44,9 +44,9 @@ forbid importing it) and LightSail snapshots (no Terraform resource exists for t
 | `infra/bootstrap/`  | Terraform layer that provisions the S3 + DynamoDB remote-state backend.            |
 | `infra/`            | Main Terraform layer — imports and manages the live LightSail deployment.          |
 | `scripts/aws/`      | Operator-facing AWS scripts: credential verification, drift inventory.             |
-| `scripts/server/`   | Operator-facing on-host scripts: idempotent provisioner (`install.py`) + tests.    |
+| `scripts/server/`   | On-host scripts: provisioner, updater, `deploy-updater.sh`, tests.                 |
 | `docs/`             | Long-form operator walkthroughs (currently: AWS CLI auth via IAM Identity Center). |
-| `server/`           | Reserved for on-host server state and the future updater (placeholder).            |
+| `server/`           | Reserved for on-host server state captures (placeholder).                          |
 | `.claude/`          | Project rules and skills used by Claude Code.                                      |
 
 Per-directory READMEs in `infra/` and `infra/bootstrap/`, plus `docs/aws-auth-setup.md`, carry the detail.
@@ -84,6 +84,14 @@ Per-directory READMEs in `infra/` and `infra/bootstrap/`, plus `docs/aws-auth-se
   `bytehorizonforge.com` zone).
 - `terraform fmt -recursive` / `terraform validate` / `terraform plan` — routine Terraform hygiene. `apply` and
   `destroy` are operator-only.
+- `scripts/server/update.py --help` — the on-host updater (lands at `/usr/local/sbin/minecraft-update.py`). Runs
+  daily under `minecraft-update.timer` (fires at `*-*-* 10:00:00 UTC` with a `RandomizedDelaySec=3600` jitter —
+  ~5 AM CDT, genuine off-peak). Sha256-driven: skips when on-disk jars match the API. Refuses to bump Paper
+  across MC versions, never touches `plugins/floodgate/key.pem`.
+- `scripts/server/deploy-updater.sh --help` — operator-side script for the existing hand-built live host. Reads
+  `.env` for SSH details, rsyncs `update.py` + `_common.py` to `/usr/local/sbin/`, then invokes the updater's
+  `--install-systemd-units` mode to drop the timer + service units. Idempotent end-to-end. Use this rather than
+  re-running `install.py` against a host that was never tested with the provisioner.
 
 ## License
 

--- a/scripts/server/_common.py
+++ b/scripts/server/_common.py
@@ -1,0 +1,467 @@
+"""Shared API/IO primitives for ``install.py`` and ``update.py``.
+
+This module is stdlib-only and side-effect-free at import time. It centralizes the artifact-metadata fetchers
+(PaperMC Fill v3, Geyser/Floodgate v2, Hangar v1), the supporting HTTP/sha256/file helpers, and the on-disk
+version-discovery readers that both the provisioner and the nightly updater depend on. The split is by side
+effects: anything that runs apt, useradd, chown, or systemctl stays in ``install.py``; anything that just
+fetches bytes or parses bytes lives here.
+
+Both ``install.py`` and ``update.py`` are deployed to the same directory on the live host (``/usr/local/sbin``
+for the updater path; the repo clone for ``install.py``), so a sibling ``_common.py`` is reachable via the
+default script-directory import path. Renaming to a package would force a wrapper or PYTHONPATH gymnastics
+without buying anything.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+# --- Constants ---------------------------------------------------------------
+
+PAPER_API_BASE = "https://fill.papermc.io/v3/projects/paper"
+GEYSER_API_BASE = "https://download.geysermc.org/v2/projects/geyser"
+FLOODGATE_API_BASE = "https://download.geysermc.org/v2/projects/floodgate"
+HANGAR_API_BASE = "https://hangar.papermc.io/api/v1/projects"
+HTTP_TIMEOUT_S = 30
+USER_AGENT = "aws-hosted-minecraft/0.1 (+https://github.com/brandonavant/aws-hosted-minecraft)"
+
+PAPER_DOWNLOAD_KEY = "server:default"
+GEYSER_LIKE_DOWNLOAD_KEY = "spigot"
+HANGAR_DOWNLOAD_PLATFORM = "PAPER"
+
+VERSION_HISTORY_FILE = "version_history.json"
+_VERSION_HISTORY_RE = re.compile(r'"currentVersion"\s*:\s*"git-Paper-(?P<build>\d+)\s*\(MC:\s*(?P<mc>[^)]+)\)"')
+_PLUGIN_YML_VERSION_RE = re.compile(r"^version:\s*(?P<version>.+?)\s*$", re.MULTILINE)
+
+
+# --- Exceptions --------------------------------------------------------------
+
+
+class DownloadError(RuntimeError):
+    """Raised when an HTTP fetch fails after retries or returns a malformed body."""
+
+
+class ChecksumMismatchError(RuntimeError):
+    """Raised when a downloaded artifact's sha256 does not match its expected hash."""
+
+
+# --- Datatypes ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class JarArtifact:
+    """A jar to download and place under the server tree.
+
+    Attributes:
+        label: Short human-readable label for log messages (e.g. ``"paper"``).
+        version: Human-readable version string for log messages (e.g. ``"1.21.8-60"``, ``"2.10.0-1143"``,
+            ``"5.9.1"``).
+        download_url: Direct HTTPS URL to the jar.
+        sha256: Expected sha256 hex digest of the downloaded bytes.
+        filename: Final on-disk filename (not necessarily the URL's basename).
+    """
+
+    label: str
+    version: str
+    download_url: str
+    sha256: str
+    filename: str
+
+
+# --- HTTP helpers ------------------------------------------------------------
+
+
+def http_get(url: str) -> bytes:
+    """Fetch ``url`` and return the body bytes.
+
+    Args:
+        url: HTTPS URL to fetch.
+
+    Returns:
+        Raw response body.
+
+    Raises:
+        DownloadError: When the request fails or the response is non-2xx.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:  # noqa: S310 — https only.
+            if response.status >= 400:
+                raise DownloadError(f"GET {url} returned HTTP {response.status}")
+            return response.read()
+    except urllib.error.URLError as exc:
+        raise DownloadError(f"GET {url} failed: {exc}") from exc
+
+
+def http_get_json(url: str) -> dict | list:
+    """Fetch ``url`` and parse the body as JSON.
+
+    Args:
+        url: HTTPS URL returning JSON.
+
+    Returns:
+        The decoded JSON document.
+
+    Raises:
+        DownloadError: When the fetch fails or the body is not valid JSON.
+    """
+    body = http_get(url)
+    try:
+        return json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DownloadError(f"GET {url}: response was not UTF-8 JSON ({exc})") from exc
+
+
+def http_get_text(url: str) -> str:
+    """Fetch ``url`` and decode the body as UTF-8 text.
+
+    Args:
+        url: HTTPS URL returning text.
+
+    Returns:
+        Decoded body as a string.
+
+    Raises:
+        DownloadError: When the fetch fails or the body is not valid UTF-8.
+    """
+    body = http_get(url)
+    try:
+        return body.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise DownloadError(f"GET {url}: response was not UTF-8 ({exc})") from exc
+
+
+def http_download_to_file(url: str, dest: Path) -> None:
+    """Download ``url`` to ``dest``, replacing any existing file.
+
+    The download is written to a sibling tempfile then atomically renamed so a crash never leaves a half-written
+    jar in place.
+
+    Args:
+        url: HTTPS URL to download.
+        dest: Destination path. Parent directory must exist.
+
+    Raises:
+        DownloadError: When the request fails.
+    """
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    tmp = dest.with_suffix(dest.suffix + ".partial")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:  # noqa: S310 — https only.
+            if response.status >= 400:
+                raise DownloadError(f"GET {url} returned HTTP {response.status}")
+            with tmp.open("wb") as handle:
+                shutil.copyfileobj(response, handle)
+    except urllib.error.URLError as exc:
+        if tmp.exists():
+            tmp.unlink()
+        raise DownloadError(f"download {url} failed: {exc}") from exc
+    tmp.replace(dest)
+
+
+# --- SHA256 helpers ----------------------------------------------------------
+
+
+def sha256_of_file(path: Path) -> str:
+    """Compute the sha256 hex digest of a file's bytes.
+
+    Args:
+        path: Path to a regular file.
+
+    Returns:
+        Lowercase hex digest.
+    """
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# --- Version discovery -------------------------------------------------------
+
+
+def read_mc_version_from_history(server_dir: Path) -> tuple[str, int] | None:
+    """Read the running MC version + Paper build from ``version_history.json``.
+
+    Paper writes ``version_history.json`` in the server directory after the first start; the file's
+    ``currentVersion`` field looks like ``"git-Paper-60 (MC: 1.21.8)"``.
+
+    Args:
+        server_dir: Paper server directory.
+
+    Returns:
+        A ``(mc_version, paper_build)`` tuple, or ``None`` when the file does not exist or the field is missing
+        / malformed.
+    """
+    history_path = server_dir / VERSION_HISTORY_FILE
+    if not history_path.exists():
+        return None
+    try:
+        text = history_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _VERSION_HISTORY_RE.search(text)
+    if not match:
+        return None
+    try:
+        build = int(match["build"])
+    except ValueError:
+        return None
+    return match["mc"].strip(), build
+
+
+def read_plugin_version(jar_path: Path) -> str | None:
+    """Extract the ``version`` field from a plugin jar's ``plugin.yml``.
+
+    Reads the jar's local ``plugin.yml`` entry via ``unzip -p``. ``unzip`` is in ``install.py``'s apt-install
+    list so it is always present after a fresh provision.
+
+    Real plugin.yml shapes (sampled from current upstream jars):
+
+    - Geyser-Spigot: ``version: 2.10.0-SNAPSHOT`` (no build number embedded).
+    - floodgate-spigot: ``version: 2.2.5-SNAPSHOT (b132-5a72b6a)`` (build embedded as ``b<N>``).
+    - ViaVersion: ``version: "5.9.1"`` (yaml-quoted; clean semver).
+
+    Args:
+        jar_path: Path to the plugin jar.
+
+    Returns:
+        The raw version string with surrounding quotes stripped (e.g. ``"2.10.0-SNAPSHOT"``,
+        ``"2.2.5-SNAPSHOT (b132-5a72b6a)"``, ``"5.9.1"``), or ``None`` when the jar lacks ``plugin.yml`` /
+        the version field, or ``unzip`` is not installed.
+    """
+    if not shutil.which("unzip"):
+        return None
+    proc = subprocess.run(  # noqa: S603 — argv as list, no shell.
+        ["unzip", "-p", str(jar_path), "plugin.yml"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    match = _PLUGIN_YML_VERSION_RE.search(proc.stdout)
+    if not match:
+        return None
+    return match["version"].strip().strip("'\"")
+
+
+# --- Paper artifact metadata -------------------------------------------------
+
+
+def fetch_paper_artifact(mc_version: str, build: int | str = "latest") -> JarArtifact:
+    """Fetch metadata for one Paper build and return a ``JarArtifact``.
+
+    Calls the PaperMC Fill v3 API (``GET /v3/projects/paper/versions/{mc_version}/builds/{build}``) and pulls
+    out the ``server:default`` download.
+
+    Args:
+        mc_version: Minecraft version (e.g. ``"1.21.8"``).
+        build: Paper build number, or the literal string ``"latest"``.
+
+    Returns:
+        A populated ``JarArtifact``.
+
+    Raises:
+        DownloadError: When the API call fails or the expected fields are missing from the response.
+    """
+    url = f"{PAPER_API_BASE}/versions/{mc_version}/builds/{build}"
+    payload = http_get_json(url)
+    return _paper_artifact_from_build_payload(mc_version, payload)
+
+
+def _paper_artifact_from_build_payload(mc_version: str, payload: object) -> JarArtifact:
+    """Convert a Paper build response into a ``JarArtifact``.
+
+    Args:
+        mc_version: MC version the build belongs to (used in the label).
+        payload: Decoded JSON from the Fill v3 single-build endpoint.
+
+    Returns:
+        A populated ``JarArtifact``.
+
+    Raises:
+        DownloadError: When the payload shape is unexpected.
+    """
+    if not isinstance(payload, dict):
+        raise DownloadError(f"paper build response was not an object: {type(payload).__name__}")
+    build_id = payload.get("id")
+    downloads = payload.get("downloads")
+    if not isinstance(downloads, dict) or PAPER_DOWNLOAD_KEY not in downloads:
+        raise DownloadError(f"paper build {build_id!r}: missing downloads.{PAPER_DOWNLOAD_KEY!r}")
+    entry = downloads[PAPER_DOWNLOAD_KEY]
+    if not isinstance(entry, dict):
+        raise DownloadError(f"paper build {build_id!r}: downloads.{PAPER_DOWNLOAD_KEY!r} is not an object")
+    sha256 = entry.get("checksums", {}).get("sha256") if isinstance(entry.get("checksums"), dict) else None
+    download_url = entry.get("url")
+    filename = entry.get("name", "paper.jar")
+    if not isinstance(sha256, str) or not isinstance(download_url, str) or not isinstance(filename, str):
+        raise DownloadError(f"paper build {build_id!r}: missing url / sha256 / name fields")
+    return JarArtifact(
+        label="paper",
+        version=f"{mc_version}-{build_id}",
+        download_url=download_url,
+        sha256=sha256,
+        filename=filename,
+    )
+
+
+# --- Geyser / Floodgate artifact metadata -----------------------------------
+
+
+def fetch_geyser_like_artifact(
+    project_label: str,
+    api_base: str,
+    *,
+    version: str | None,
+    build: int | None,
+) -> JarArtifact:
+    """Fetch metadata for a Geyser-style project build (geyser or floodgate).
+
+    Both projects share the v2 ``download.geysermc.org`` API shape. When ``version`` is ``None``, the latest
+    version published by the API is used; same for ``build`` (latest in that version's build list — last
+    element of the ``builds`` array, which is sorted ascending).
+
+    Args:
+        project_label: ``"geyser"`` or ``"floodgate"``.
+        api_base: Project base URL.
+        version: Pin to this version, or ``None`` for the latest published.
+        build: Pin to this numeric build, or ``None`` for the latest in version.
+
+    Returns:
+        A populated ``JarArtifact`` for the spigot variant.
+
+    Raises:
+        DownloadError: On API failure or unexpected shape.
+    """
+    if version is None:
+        project_payload = http_get_json(api_base)
+        if not isinstance(project_payload, dict):
+            raise DownloadError(f"{project_label} project response was not an object")
+        versions = project_payload.get("versions")
+        if not isinstance(versions, list) or not versions:
+            raise DownloadError(f"{project_label} project response: empty 'versions' list")
+        version = str(versions[-1])
+    if build is None:
+        version_payload = http_get_json(f"{api_base}/versions/{version}")
+        if not isinstance(version_payload, dict):
+            raise DownloadError(f"{project_label} version {version!r}: response was not an object")
+        builds = version_payload.get("builds")
+        if not isinstance(builds, list) or not builds:
+            raise DownloadError(f"{project_label} version {version!r}: empty 'builds' list")
+        build = int(builds[-1])
+    build_payload = http_get_json(f"{api_base}/versions/{version}/builds/{build}")
+    return _geyser_like_artifact_from_payload(project_label, api_base, build_payload)
+
+
+def _geyser_like_artifact_from_payload(project_label: str, api_base: str, payload: object) -> JarArtifact:
+    """Convert a Geyser/Floodgate single-build payload into a ``JarArtifact``.
+
+    Args:
+        project_label: ``"geyser"`` or ``"floodgate"``.
+        api_base: Project base URL (used to construct the download URL).
+        payload: Decoded JSON from the v2 single-build endpoint.
+
+    Returns:
+        A populated ``JarArtifact``.
+
+    Raises:
+        DownloadError: When the payload shape is unexpected.
+    """
+    if not isinstance(payload, dict):
+        raise DownloadError(f"{project_label} build response was not an object")
+    version = payload.get("version")
+    build = payload.get("build")
+    downloads = payload.get("downloads")
+    if not isinstance(version, str) or not isinstance(build, int) or not isinstance(downloads, dict):
+        raise DownloadError(f"{project_label} build response: missing version / build / downloads")
+    entry = downloads.get(GEYSER_LIKE_DOWNLOAD_KEY)
+    if not isinstance(entry, dict):
+        raise DownloadError(f"{project_label} build {build}: downloads.{GEYSER_LIKE_DOWNLOAD_KEY!r} missing")
+    sha256 = entry.get("sha256")
+    filename = entry.get("name")
+    if not isinstance(sha256, str) or not isinstance(filename, str):
+        raise DownloadError(f"{project_label} build {build}: spigot entry missing sha256 / name")
+    download_url = f"{api_base}/versions/{version}/builds/{build}/downloads/{GEYSER_LIKE_DOWNLOAD_KEY}"
+    return JarArtifact(
+        label=project_label,
+        version=f"{version}-{build}",
+        download_url=download_url,
+        sha256=sha256,
+        filename=filename,
+    )
+
+
+# --- ViaVersion (Hangar) artifact metadata -----------------------------------
+
+
+def fetch_viaversion_artifact(version_name: str | None) -> JarArtifact:
+    """Fetch metadata for ViaVersion via the Hangar API.
+
+    Hangar's ``/latest?channel=Release`` endpoint returns a plain version name (e.g. ``"5.9.1"``); per-version
+    metadata comes from ``/versions/{name}``. When ``version_name`` is ``None``, the latest Release-channel
+    version is used.
+
+    Args:
+        version_name: Pin to this Hangar version name, or ``None`` for latest.
+
+    Returns:
+        A populated ``JarArtifact`` for the PAPER platform download.
+
+    Raises:
+        DownloadError: On API failure or unexpected shape.
+    """
+    project_url = f"{HANGAR_API_BASE}/ViaVersion/ViaVersion"
+    if version_name is None:
+        version_name = http_get_text(f"{project_url}/latest?channel=Release").strip()
+        if not version_name:
+            raise DownloadError("Hangar /latest?channel=Release returned an empty body")
+    payload = http_get_json(f"{project_url}/versions/{version_name}")
+    return _viaversion_artifact_from_payload(payload)
+
+
+def _viaversion_artifact_from_payload(payload: object) -> JarArtifact:
+    """Convert a Hangar single-version payload into a ``JarArtifact``.
+
+    Args:
+        payload: Decoded JSON from ``/api/v1/projects/ViaVersion/ViaVersion/versions/{name}``.
+
+    Returns:
+        A populated ``JarArtifact``.
+
+    Raises:
+        DownloadError: When the payload shape is unexpected.
+    """
+    if not isinstance(payload, dict):
+        raise DownloadError("Hangar version response was not an object")
+    name = payload.get("name")
+    downloads = payload.get("downloads")
+    if not isinstance(name, str) or not isinstance(downloads, dict):
+        raise DownloadError("Hangar version response: missing name / downloads")
+    entry = downloads.get(HANGAR_DOWNLOAD_PLATFORM)
+    if not isinstance(entry, dict):
+        raise DownloadError(f"Hangar version {name!r}: downloads.{HANGAR_DOWNLOAD_PLATFORM!r} missing")
+    file_info = entry.get("fileInfo")
+    if not isinstance(file_info, dict):
+        raise DownloadError(f"Hangar version {name!r}: PAPER entry missing fileInfo")
+    sha256 = file_info.get("sha256Hash")
+    filename = file_info.get("name")
+    download_url = entry.get("downloadUrl")
+    if not isinstance(sha256, str) or not isinstance(filename, str) or not isinstance(download_url, str):
+        raise DownloadError(f"Hangar version {name!r}: missing sha256 / name / downloadUrl")
+    return JarArtifact(
+        label="viaversion",
+        version=name,
+        download_url=download_url,
+        sha256=sha256,
+        filename="ViaVersion.jar",
+    )

--- a/scripts/server/deploy-updater.sh
+++ b/scripts/server/deploy-updater.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Deploy the Minecraft updater to the live host. Reads SSH details from the repo-root .env, rsyncs
+# update.py + _common.py to /usr/local/sbin/ on the host, then SSHs in to invoke the updater's
+# --install-systemd-units mode so the systemd timer + service units land idempotently.
+#
+# Designed to be re-runnable: rsync ships only changed bytes, and the self-install mode is a no-op when
+# the units already match the desired state. The operator runs this whenever update.py or _common.py
+# changes locally; the live host catches up without any manual SSH step.
+#
+# Why not bake this into install.py? install.py is the fresh-host provisioner — it runs on a brand-new
+# LightSail instance during initial bring-up. This script is the lower-friction path for the existing
+# hand-built live host, where running install.py is undesired (it would touch apt, users, the systemd
+# minecraft.service, etc.). deploy-updater.sh ships ONLY the updater bits.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ENV_FILE="${REPO_ROOT}/.env"
+REMOTE_INSTALL_DIR="/usr/local/sbin"
+REMOTE_UPDATER_PATH="${REMOTE_INSTALL_DIR}/minecraft-update.py"
+SOURCE_FILES=("update.py" "_common.py")
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/server/deploy-updater.sh [--dry-run] [-h|--help]
+
+Deploys update.py + _common.py to the live host's /usr/local/sbin/ and runs the updater's
+--install-systemd-units mode to install the systemd timer and service units.
+
+Reads .env at the repo root for SSH details:
+  MC_SSH_HOST   IPv4 or DNS name of the live host.
+  MC_SSH_USER   SSH login user (e.g. ubuntu on LightSail Ubuntu).
+  MC_SSH_KEY    Path to the SSH private key (.pem).
+
+Idempotent end-to-end:
+  - rsync ships zero bytes when the source files match the live host's copies.
+  - --install-systemd-units rewrites unit files only on content drift, runs daemon-reload only when
+    units change, and enable --now is a no-op when the timer is already active.
+
+Options:
+  --dry-run     Print the rsync + ssh commands without executing them.
+  -h, --help    Print this message and exit.
+EOF
+}
+
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *)
+      echo "error: unknown argument $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "error: ${ENV_FILE} not found. Copy .env.example and fill in MC_SSH_*." >&2
+  exit 2
+fi
+
+# Load .env without exporting unrelated variables. Only MC_SSH_* matters here. The path is runtime-
+# determined so SC1090/SC1091 are suppressed at the source line.
+set -a
+# shellcheck disable=SC1090,SC1091
+. "${ENV_FILE}"
+set +a
+
+MISSING=""
+[ -z "${MC_SSH_HOST:-}" ] && MISSING="${MISSING} MC_SSH_HOST"
+[ -z "${MC_SSH_USER:-}" ] && MISSING="${MISSING} MC_SSH_USER"
+[ -z "${MC_SSH_KEY:-}" ] && MISSING="${MISSING} MC_SSH_KEY"
+if [ -n "${MISSING}" ]; then
+  echo "error: missing required .env vars:${MISSING}" >&2
+  echo "       Update ${ENV_FILE} from .env.example before re-running." >&2
+  exit 2
+fi
+if [ ! -f "${MC_SSH_KEY}" ]; then
+  echo "error: MC_SSH_KEY=${MC_SSH_KEY} does not exist" >&2
+  exit 2
+fi
+
+for file in "${SOURCE_FILES[@]}"; do
+  if [ ! -f "${SCRIPT_DIR}/${file}" ]; then
+    echo "error: source file ${SCRIPT_DIR}/${file} not found" >&2
+    exit 2
+  fi
+done
+
+SSH_OPTS=(-i "${MC_SSH_KEY}" -o StrictHostKeyChecking=accept-new)
+
+run_cmd() {
+  if [ "${DRY_RUN}" -eq 1 ]; then
+    echo "[dry-run] $*"
+  else
+    echo "[run] $*"
+    "$@"
+  fi
+}
+
+echo "==> rsync update.py + _common.py → ${MC_SSH_USER}@${MC_SSH_HOST}:${REMOTE_INSTALL_DIR}/"
+# --rsync-path="sudo rsync" runs the remote-side rsync as root so it can write to /usr/local/sbin.
+# LightSail's default ubuntu user has NOPASSWD sudo, so this stays non-interactive.
+RSYNC_SOURCES=()
+for file in "${SOURCE_FILES[@]}"; do
+  RSYNC_SOURCES+=("${SCRIPT_DIR}/${file}")
+done
+run_cmd rsync \
+  -e "ssh ${SSH_OPTS[*]}" \
+  --rsync-path="sudo rsync" \
+  --chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r \
+  "${RSYNC_SOURCES[@]}" \
+  "${MC_SSH_USER}@${MC_SSH_HOST}:${REMOTE_INSTALL_DIR}/"
+
+# The local source is update.py; the remote install path is minecraft-update.py. rsync ships under the
+# original name first; rename + chmod via a single remote sudo invocation so the destination has the
+# expected basename and is executable. install -m 0755 is idempotent: a re-run with the same content is
+# a content-preserving mode/owner reset.
+echo "==> rename update.py → minecraft-update.py and ensure executable"
+RENAME_CMD="sudo install -m 0755 -o root -g root"
+RENAME_CMD="${RENAME_CMD} ${REMOTE_INSTALL_DIR}/update.py ${REMOTE_UPDATER_PATH}"
+RENAME_CMD="${RENAME_CMD} && sudo rm -f ${REMOTE_INSTALL_DIR}/update.py"
+run_cmd ssh "${SSH_OPTS[@]}" "${MC_SSH_USER}@${MC_SSH_HOST}" "${RENAME_CMD}"
+
+echo "==> invoke ${REMOTE_UPDATER_PATH} --install-systemd-units"
+run_cmd ssh "${SSH_OPTS[@]}" "${MC_SSH_USER}@${MC_SSH_HOST}" \
+  "sudo ${REMOTE_UPDATER_PATH} --install-systemd-units"
+
+echo "==> done. Verify with:"
+echo "    ssh -i ${MC_SSH_KEY} ${MC_SSH_USER}@${MC_SSH_HOST} systemctl list-timers minecraft-update.timer"

--- a/scripts/server/install.py
+++ b/scripts/server/install.py
@@ -26,19 +26,29 @@ existing Bedrock player.
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
 import os
-import re
 import shlex
-import shutil
 import subprocess
 import sys
-import urllib.error
-import urllib.request
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+
+from _common import (
+    FLOODGATE_API_BASE,
+    GEYSER_API_BASE,
+    VERSION_HISTORY_FILE,
+    ChecksumMismatchError,
+    DownloadError,
+    JarArtifact,
+    fetch_geyser_like_artifact,
+    fetch_paper_artifact,
+    fetch_viaversion_artifact,
+    http_download_to_file,
+    http_get,
+    read_mc_version_from_history,
+    sha256_of_file,
+)
 
 # --- Constants ---------------------------------------------------------------
 
@@ -65,16 +75,10 @@ COMMON_PACKAGES: tuple[str, ...] = ("unzip", "wget", "ca-certificates", "gnupg")
 SYSTEMD_UNIT_PATH = Path("/etc/systemd/system/minecraft.service")
 SYSTEMD_UNIT_NAME = "minecraft.service"
 
-PAPER_API_BASE = "https://fill.papermc.io/v3/projects/paper"
-GEYSER_API_BASE = "https://download.geysermc.org/v2/projects/geyser"
-FLOODGATE_API_BASE = "https://download.geysermc.org/v2/projects/floodgate"
-HANGAR_API_BASE = "https://hangar.papermc.io/api/v1/projects"
-HTTP_TIMEOUT_S = 30
-USER_AGENT = "aws-hosted-minecraft-installer/0.1 (+https://github.com/brandonavant/aws-hosted-minecraft)"
-
-PAPER_DOWNLOAD_KEY = "server:default"
-GEYSER_LIKE_DOWNLOAD_KEY = "spigot"
-HANGAR_DOWNLOAD_PLATFORM = "PAPER"
+UPDATER_SOURCE_FILES: tuple[str, ...] = ("update.py", "_common.py")
+UPDATER_INSTALL_DIR = Path("/usr/local/sbin")
+UPDATER_SCRIPT_NAME = "minecraft-update.py"
+UPDATER_SCRIPT_PATH = UPDATER_INSTALL_DIR / UPDATER_SCRIPT_NAME
 
 SYSTEMD_UNIT_TEMPLATE = """\
 [Unit]
@@ -105,10 +109,6 @@ cd {server_dir}
 exec /usr/bin/java -Xms{heap} -Xmx{heap} -jar {server_dir}/{paper_jar} --nogui
 """
 
-VERSION_HISTORY_FILE = "version_history.json"
-_VERSION_HISTORY_RE = re.compile(r'"currentVersion"\s*:\s*"git-Paper-(?P<build>\d+)\s*\(MC:\s*(?P<mc>[^)]+)\)"')
-_PLUGIN_YML_VERSION_RE = re.compile(r"^version:\s*(?P<version>.+?)\s*$", re.MULTILINE)
-
 
 # --- Exceptions --------------------------------------------------------------
 
@@ -129,34 +129,7 @@ class VersionDiscoveryError(InstallError):
     """Raised when a required version cannot be discovered from CLI or volume."""
 
 
-class DownloadError(InstallError):
-    """Raised when an HTTP fetch fails after retries."""
-
-
-class ChecksumMismatchError(InstallError):
-    """Raised when a downloaded artifact's sha256 does not match expected."""
-
-
 # --- Datatypes ---------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class JarArtifact:
-    """A jar to download and place under the server tree.
-
-    Attributes:
-        label: Short human-readable label for log messages (e.g. ``"paper"``).
-        version: Human-readable version string for log messages.
-        download_url: Direct HTTPS URL to the jar.
-        sha256: Expected sha256 hex digest of the downloaded bytes.
-        filename: Final on-disk filename (not necessarily the URL's basename).
-    """
-
-    label: str
-    version: str
-    download_url: str
-    sha256: str
-    filename: str
 
 
 @dataclass(frozen=True)
@@ -238,116 +211,6 @@ def run_command(
         text=True,
         input=input_text,
     )
-
-
-# --- HTTP helpers ------------------------------------------------------------
-
-
-def http_get(url: str) -> bytes:
-    """Fetch ``url`` and return the body bytes.
-
-    Args:
-        url: HTTPS URL to fetch.
-
-    Returns:
-        Raw response body.
-
-    Raises:
-        DownloadError: When the request fails or the response is non-2xx.
-    """
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    try:
-        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:  # noqa: S310 — https only.
-            if response.status >= 400:
-                raise DownloadError(f"GET {url} returned HTTP {response.status}")
-            return response.read()
-    except urllib.error.URLError as exc:
-        raise DownloadError(f"GET {url} failed: {exc}") from exc
-
-
-def http_get_json(url: str) -> dict | list:
-    """Fetch ``url`` and parse the body as JSON.
-
-    Args:
-        url: HTTPS URL returning JSON.
-
-    Returns:
-        The decoded JSON document.
-
-    Raises:
-        DownloadError: When the fetch fails or the body is not valid JSON.
-    """
-    body = http_get(url)
-    try:
-        return json.loads(body.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise DownloadError(f"GET {url}: response was not UTF-8 JSON ({exc})") from exc
-
-
-def http_get_text(url: str) -> str:
-    """Fetch ``url`` and decode the body as UTF-8 text.
-
-    Args:
-        url: HTTPS URL returning text.
-
-    Returns:
-        Decoded body as a string.
-
-    Raises:
-        DownloadError: When the fetch fails or the body is not valid UTF-8.
-    """
-    body = http_get(url)
-    try:
-        return body.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise DownloadError(f"GET {url}: response was not UTF-8 ({exc})") from exc
-
-
-def http_download_to_file(url: str, dest: Path) -> None:
-    """Download ``url`` to ``dest``, replacing any existing file.
-
-    The download is written to a sibling tempfile then atomically renamed so a crash never leaves a half-written
-    jar in place.
-
-    Args:
-        url: HTTPS URL to download.
-        dest: Destination path. Parent directory must exist.
-
-    Raises:
-        DownloadError: When the request fails.
-    """
-    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
-    tmp = dest.with_suffix(dest.suffix + ".partial")
-    try:
-        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:  # noqa: S310 — https only.
-            if response.status >= 400:
-                raise DownloadError(f"GET {url} returned HTTP {response.status}")
-            with tmp.open("wb") as handle:
-                shutil.copyfileobj(response, handle)
-    except urllib.error.URLError as exc:
-        if tmp.exists():
-            tmp.unlink()
-        raise DownloadError(f"download {url} failed: {exc}") from exc
-    tmp.replace(dest)
-
-
-# --- SHA256 helpers ----------------------------------------------------------
-
-
-def sha256_of_file(path: Path) -> str:
-    """Compute the sha256 hex digest of a file's bytes.
-
-    Args:
-        path: Path to a regular file.
-
-    Returns:
-        Lowercase hex digest.
-    """
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
 
 
 # --- Pre-flight checks -------------------------------------------------------
@@ -705,280 +568,6 @@ def ensure_directory(
     return created
 
 
-# --- Version discovery -------------------------------------------------------
-
-
-def read_mc_version_from_history(server_dir: Path) -> tuple[str, int] | None:
-    """Read the running MC version + Paper build from ``version_history.json``.
-
-    Paper writes ``version_history.json`` in the server directory after the first start; the file's
-    ``currentVersion`` field looks like ``"git-Paper-60 (MC: 1.21.8)"``.
-
-    Args:
-        server_dir: Paper server directory.
-
-    Returns:
-        A ``(mc_version, paper_build)`` tuple, or ``None`` when the file does not exist or the field is missing
-        / malformed.
-    """
-    history_path = server_dir / VERSION_HISTORY_FILE
-    if not history_path.exists():
-        return None
-    try:
-        text = history_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-    match = _VERSION_HISTORY_RE.search(text)
-    if not match:
-        return None
-    try:
-        build = int(match["build"])
-    except ValueError:
-        return None
-    return match["mc"].strip(), build
-
-
-def read_plugin_version(jar_path: Path) -> str | None:
-    """Extract the ``version`` field from a plugin jar's ``plugin.yml``.
-
-    Reads the jar's local ``plugin.yml`` entry via ``unzip -p``. ``unzip`` is in this script's apt-install list
-    so it will be present after the first run.
-
-    Args:
-        jar_path: Path to the plugin jar.
-
-    Returns:
-        The version string, or ``None`` when the jar lacks ``plugin.yml`` / the version field, or ``unzip`` is
-        not yet installed.
-    """
-    if not shutil.which("unzip"):
-        return None
-    proc = subprocess.run(  # noqa: S603 — argv as list, no shell.
-        ["unzip", "-p", str(jar_path), "plugin.yml"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0 or not proc.stdout.strip():
-        return None
-    match = _PLUGIN_YML_VERSION_RE.search(proc.stdout)
-    if not match:
-        return None
-    return match["version"].strip().strip("'\"")
-
-
-# --- Paper download ----------------------------------------------------------
-
-
-def fetch_paper_artifact(mc_version: str, build: int | str = "latest") -> JarArtifact:
-    """Fetch metadata for one Paper build and return a ``JarArtifact``.
-
-    Calls the PaperMC Fill v3 API (``GET /v3/projects/paper/versions/{mc_version}/builds/{build}``) and pulls out
-    the ``server:default`` download.
-
-    Args:
-        mc_version: Minecraft version (e.g. ``"1.21.8"``).
-        build: Paper build number, or the literal string ``"latest"``.
-
-    Returns:
-        A populated ``JarArtifact``.
-
-    Raises:
-        DownloadError: When the API call fails or the expected fields are missing from the response.
-    """
-    url = f"{PAPER_API_BASE}/versions/{mc_version}/builds/{build}"
-    payload = http_get_json(url)
-    return _paper_artifact_from_build_payload(mc_version, payload)
-
-
-def _paper_artifact_from_build_payload(mc_version: str, payload: object) -> JarArtifact:
-    """Convert a Paper build response into a ``JarArtifact``.
-
-    Args:
-        mc_version: MC version the build belongs to (used in the label).
-        payload: Decoded JSON from the Fill v3 single-build endpoint.
-
-    Returns:
-        A populated ``JarArtifact``.
-
-    Raises:
-        DownloadError: When the payload shape is unexpected.
-    """
-    if not isinstance(payload, dict):
-        raise DownloadError(f"paper build response was not an object: {type(payload).__name__}")
-    build_id = payload.get("id")
-    downloads = payload.get("downloads")
-    if not isinstance(downloads, dict) or PAPER_DOWNLOAD_KEY not in downloads:
-        raise DownloadError(f"paper build {build_id!r}: missing downloads.{PAPER_DOWNLOAD_KEY!r}")
-    entry = downloads[PAPER_DOWNLOAD_KEY]
-    if not isinstance(entry, dict):
-        raise DownloadError(f"paper build {build_id!r}: downloads.{PAPER_DOWNLOAD_KEY!r} is not an object")
-    sha256 = entry.get("checksums", {}).get("sha256") if isinstance(entry.get("checksums"), dict) else None
-    download_url = entry.get("url")
-    filename = entry.get("name", PAPER_JAR_NAME)
-    if not isinstance(sha256, str) or not isinstance(download_url, str) or not isinstance(filename, str):
-        raise DownloadError(f"paper build {build_id!r}: missing url / sha256 / name fields")
-    return JarArtifact(
-        label="paper",
-        version=f"{mc_version}-{build_id}",
-        download_url=download_url,
-        sha256=sha256,
-        filename=filename,
-    )
-
-
-# --- Geyser / Floodgate download --------------------------------------------
-
-
-def fetch_geyser_like_artifact(
-    project_label: str,
-    api_base: str,
-    *,
-    version: str | None,
-    build: int | None,
-) -> JarArtifact:
-    """Fetch metadata for a Geyser-style project build (geyser or floodgate).
-
-    Both projects share the v2 ``download.geysermc.org`` API shape. When ``version`` is ``None``, the latest
-    version published by the API is used; same for ``build`` (latest in that version's build list — last element
-    of the ``builds`` array, which is sorted ascending).
-
-    Args:
-        project_label: ``"geyser"`` or ``"floodgate"``.
-        api_base: Project base URL.
-        version: Pin to this version, or ``None`` for the latest published.
-        build: Pin to this numeric build, or ``None`` for the latest in version.
-
-    Returns:
-        A populated ``JarArtifact`` for the spigot variant.
-
-    Raises:
-        DownloadError: On API failure or unexpected shape.
-    """
-    if version is None:
-        project_payload = http_get_json(api_base)
-        if not isinstance(project_payload, dict):
-            raise DownloadError(f"{project_label} project response was not an object")
-        versions = project_payload.get("versions")
-        if not isinstance(versions, list) or not versions:
-            raise DownloadError(f"{project_label} project response: empty 'versions' list")
-        version = str(versions[-1])
-    if build is None:
-        version_payload = http_get_json(f"{api_base}/versions/{version}")
-        if not isinstance(version_payload, dict):
-            raise DownloadError(f"{project_label} version {version!r}: response was not an object")
-        builds = version_payload.get("builds")
-        if not isinstance(builds, list) or not builds:
-            raise DownloadError(f"{project_label} version {version!r}: empty 'builds' list")
-        build = int(builds[-1])
-    build_payload = http_get_json(f"{api_base}/versions/{version}/builds/{build}")
-    return _geyser_like_artifact_from_payload(project_label, api_base, build_payload)
-
-
-def _geyser_like_artifact_from_payload(project_label: str, api_base: str, payload: object) -> JarArtifact:
-    """Convert a Geyser/Floodgate single-build payload into a ``JarArtifact``.
-
-    Args:
-        project_label: ``"geyser"`` or ``"floodgate"``.
-        api_base: Project base URL (used to construct the download URL).
-        payload: Decoded JSON from the v2 single-build endpoint.
-
-    Returns:
-        A populated ``JarArtifact``.
-
-    Raises:
-        DownloadError: When the payload shape is unexpected.
-    """
-    if not isinstance(payload, dict):
-        raise DownloadError(f"{project_label} build response was not an object")
-    version = payload.get("version")
-    build = payload.get("build")
-    downloads = payload.get("downloads")
-    if not isinstance(version, str) or not isinstance(build, int) or not isinstance(downloads, dict):
-        raise DownloadError(f"{project_label} build response: missing version / build / downloads")
-    entry = downloads.get(GEYSER_LIKE_DOWNLOAD_KEY)
-    if not isinstance(entry, dict):
-        raise DownloadError(f"{project_label} build {build}: downloads.{GEYSER_LIKE_DOWNLOAD_KEY!r} missing")
-    sha256 = entry.get("sha256")
-    filename = entry.get("name")
-    if not isinstance(sha256, str) or not isinstance(filename, str):
-        raise DownloadError(f"{project_label} build {build}: spigot entry missing sha256 / name")
-    download_url = f"{api_base}/versions/{version}/builds/{build}/downloads/{GEYSER_LIKE_DOWNLOAD_KEY}"
-    return JarArtifact(
-        label=project_label,
-        version=f"{version}-{build}",
-        download_url=download_url,
-        sha256=sha256,
-        filename=filename,
-    )
-
-
-# --- ViaVersion download (Hangar) -------------------------------------------
-
-
-def fetch_viaversion_artifact(version_name: str | None) -> JarArtifact:
-    """Fetch metadata for ViaVersion via the Hangar API.
-
-    Hangar's ``/latest?channel=Release`` endpoint returns a plain version name (e.g. ``"5.9.1"``); per-version
-    metadata comes from ``/versions/{name}``. When ``version_name`` is ``None``, the latest Release-channel
-    version is used.
-
-    Args:
-        version_name: Pin to this Hangar version name, or ``None`` for latest.
-
-    Returns:
-        A populated ``JarArtifact`` for the PAPER platform download.
-
-    Raises:
-        DownloadError: On API failure or unexpected shape.
-    """
-    project_url = f"{HANGAR_API_BASE}/ViaVersion/ViaVersion"
-    if version_name is None:
-        version_name = http_get_text(f"{project_url}/latest?channel=Release").strip()
-        if not version_name:
-            raise DownloadError("Hangar /latest?channel=Release returned an empty body")
-    payload = http_get_json(f"{project_url}/versions/{version_name}")
-    return _viaversion_artifact_from_payload(payload)
-
-
-def _viaversion_artifact_from_payload(payload: object) -> JarArtifact:
-    """Convert a Hangar single-version payload into a ``JarArtifact``.
-
-    Args:
-        payload: Decoded JSON from ``/api/v1/projects/ViaVersion/ViaVersion/versions/{name}``.
-
-    Returns:
-        A populated ``JarArtifact``.
-
-    Raises:
-        DownloadError: When the payload shape is unexpected.
-    """
-    if not isinstance(payload, dict):
-        raise DownloadError("Hangar version response was not an object")
-    name = payload.get("name")
-    downloads = payload.get("downloads")
-    if not isinstance(name, str) or not isinstance(downloads, dict):
-        raise DownloadError("Hangar version response: missing name / downloads")
-    entry = downloads.get(HANGAR_DOWNLOAD_PLATFORM)
-    if not isinstance(entry, dict):
-        raise DownloadError(f"Hangar version {name!r}: downloads.{HANGAR_DOWNLOAD_PLATFORM!r} missing")
-    file_info = entry.get("fileInfo")
-    if not isinstance(file_info, dict):
-        raise DownloadError(f"Hangar version {name!r}: PAPER entry missing fileInfo")
-    sha256 = file_info.get("sha256Hash")
-    filename = file_info.get("name")
-    download_url = entry.get("downloadUrl")
-    if not isinstance(sha256, str) or not isinstance(filename, str) or not isinstance(download_url, str):
-        raise DownloadError(f"Hangar version {name!r}: missing sha256 / name / downloadUrl")
-    return JarArtifact(
-        label="viaversion",
-        version=name,
-        download_url=download_url,
-        sha256=sha256,
-        filename="ViaVersion.jar",
-    )
-
-
 # --- Download + place --------------------------------------------------------
 
 
@@ -1178,6 +767,68 @@ def ensure_systemd_unit(
         owner_user=None,
         owner_group=None,
         mode=0o644,
+        dry_run=dry_run,
+    )
+
+
+# --- Updater deployment ------------------------------------------------------
+
+
+def deploy_updater(source_dir: Path, *, dry_run: bool = False) -> bool:
+    """Copy ``update.py`` and ``_common.py`` from ``source_dir`` to ``UPDATER_INSTALL_DIR``.
+
+    Both files travel together: ``update.py`` is renamed to ``minecraft-update.py`` at the destination so
+    the systemd ``ExecStart=`` path matches operator expectations; ``_common.py`` lands beside it so the
+    script's same-dir import resolves at runtime. The copy is idempotent — files are rewritten only when
+    their content differs from the existing on-disk file.
+
+    Args:
+        source_dir: Directory containing the source files. Typically ``Path(__file__).parent``.
+        dry_run: When true, log the planned copies without performing them.
+
+    Returns:
+        ``True`` when any file was written by this call, ``False`` when every destination already matched.
+
+    Raises:
+        InstallError: When a source file is missing.
+    """
+    UPDATER_INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+    any_changed = False
+    for source_name in UPDATER_SOURCE_FILES:
+        source_path = source_dir / source_name
+        if not source_path.exists():
+            raise InstallError(f"updater source file missing: {source_path}")
+        dest_name = UPDATER_SCRIPT_NAME if source_name == "update.py" else source_name
+        dest_path = UPDATER_INSTALL_DIR / dest_name
+        mode = 0o755 if source_name == "update.py" else 0o644
+        source_bytes = source_path.read_bytes()
+        if dest_path.exists() and dest_path.read_bytes() == source_bytes:
+            existing_mode = dest_path.stat().st_mode & 0o7777
+            if existing_mode == mode:
+                print(f"[skip] {dest_path} already matches {source_path.name}", file=sys.stderr)
+                continue
+        if dry_run:
+            print(f"[dry-run] copy {source_path} → {dest_path} (mode {oct(mode)})", file=sys.stderr)
+            any_changed = True
+            continue
+        dest_path.write_bytes(source_bytes)
+        dest_path.chmod(mode)
+        print(f"[copy] {source_path} → {dest_path}", file=sys.stderr)
+        any_changed = True
+    return any_changed
+
+
+def invoke_updater_install_systemd_units(*, dry_run: bool = False) -> None:
+    """Run ``minecraft-update.py --install-systemd-units`` once via subprocess.
+
+    The updater's self-install mode is fully idempotent on its own — repeat calls produce no side effects
+    when units are already current — so this caller does not need to gate on whether it ran before.
+
+    Args:
+        dry_run: When true, log the command without executing it.
+    """
+    run_command(
+        [sys.executable, str(UPDATER_SCRIPT_PATH), "--install-systemd-units"],
         dry_run=dry_run,
     )
 
@@ -1390,6 +1041,12 @@ def install(args: argparse.Namespace) -> int:
     if unit_changed:
         systemctl_daemon_reload(dry_run=args.dry_run)
     systemctl_enable_now(SYSTEMD_UNIT_NAME, dry_run=args.dry_run)
+
+    # Updater deployment: copy update.py + _common.py to /usr/local/sbin and invoke the updater's own
+    # self-install mode to drop the systemd units. The updater is the source of truth for its unit content
+    # so install.py never emits update-timer/service templates directly.
+    deploy_updater(Path(__file__).resolve().parent, dry_run=args.dry_run)
+    invoke_updater_install_systemd_units(dry_run=args.dry_run)
     return 0
 
 

--- a/scripts/server/test_install.py
+++ b/scripts/server/test_install.py
@@ -17,6 +17,22 @@ from unittest import mock
 
 import pytest
 
+from _common import (
+    FLOODGATE_API_BASE,
+    GEYSER_API_BASE,
+    PAPER_API_BASE,
+    ChecksumMismatchError,
+    DownloadError,
+    JarArtifact,
+    _geyser_like_artifact_from_payload,
+    _paper_artifact_from_build_payload,
+    _viaversion_artifact_from_payload,
+    fetch_geyser_like_artifact,
+    fetch_paper_artifact,
+    fetch_viaversion_artifact,
+    read_mc_version_from_history,
+    sha256_of_file,
+)
 from install import (
     CORRETTO_REPO_LINE,
     DEFAULT_DATA_ROOT,
@@ -24,27 +40,20 @@ from install import (
     DEFAULT_HEAP,
     DEFAULT_USER,
     EULA_CONTENT,
-    FLOODGATE_API_BASE,
-    GEYSER_API_BASE,
-    HANGAR_API_BASE,
-    PAPER_API_BASE,
     SYSTEMD_UNIT_NAME,
-    ChecksumMismatchError,
-    DownloadError,
+    UPDATER_SCRIPT_NAME,
     FloodgateKeyMissingError,
+    InstallError,
     InstallPaths,
-    JarArtifact,
     PreflightError,
     VersionDiscoveryError,
-    _geyser_like_artifact_from_payload,
-    _paper_artifact_from_build_payload,
-    _viaversion_artifact_from_payload,
     apt_install,
     apt_packages_installed,
     assert_floodgate_key_present,
     assert_ubuntu_2204,
     assert_volume_mounted,
     build_argument_parser,
+    deploy_updater,
     download_and_place_jar,
     ensure_directory,
     ensure_eula,
@@ -52,16 +61,12 @@ from install import (
     ensure_start_script,
     ensure_systemd_unit,
     ensure_user,
-    fetch_geyser_like_artifact,
-    fetch_paper_artifact,
-    fetch_viaversion_artifact,
+    invoke_updater_install_systemd_units,
     main,
     parse_os_release,
-    read_mc_version_from_history,
     render_start_script,
     render_systemd_unit,
     resolve_versions,
-    sha256_of_file,
     write_file_if_changed,
 )
 
@@ -717,6 +722,81 @@ def test_corretto_repo_line_signed_by_keyring() -> None:
     """The committed apt source line includes ``signed-by=…/corretto-keyring.gpg``."""
     assert "signed-by=/usr/share/keyrings/corretto-keyring.gpg" in CORRETTO_REPO_LINE
     assert "https://apt.corretto.aws stable main" in CORRETTO_REPO_LINE
+
+
+# --- Updater deployment ------------------------------------------------------
+
+
+def test_deploy_updater_copies_both_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The first deploy writes both files with the right modes and renames update.py."""
+    source = tmp_path / "src"
+    install_dir = tmp_path / "sbin"
+    source.mkdir()
+    (source / "update.py").write_text("#!/usr/bin/env python3\nprint('updater')\n")
+    (source / "_common.py").write_text("# shared\n")
+    monkeypatch.setattr("install.UPDATER_INSTALL_DIR", install_dir)
+    monkeypatch.setattr("install.UPDATER_SCRIPT_PATH", install_dir / UPDATER_SCRIPT_NAME)
+    changed = deploy_updater(source)
+    assert changed is True
+    target_update = install_dir / UPDATER_SCRIPT_NAME
+    target_common = install_dir / "_common.py"
+    assert target_update.read_text() == "#!/usr/bin/env python3\nprint('updater')\n"
+    assert target_common.read_text() == "# shared\n"
+    assert target_update.stat().st_mode & 0o7777 == 0o755
+    assert target_common.stat().st_mode & 0o7777 == 0o644
+
+
+def test_deploy_updater_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A second deploy with identical source content is a no-op."""
+    source = tmp_path / "src"
+    install_dir = tmp_path / "sbin"
+    source.mkdir()
+    (source / "update.py").write_text("body\n")
+    (source / "_common.py").write_text("common\n")
+    monkeypatch.setattr("install.UPDATER_INSTALL_DIR", install_dir)
+    monkeypatch.setattr("install.UPDATER_SCRIPT_PATH", install_dir / UPDATER_SCRIPT_NAME)
+    deploy_updater(source)
+    assert deploy_updater(source) is False
+
+
+def test_deploy_updater_rewrites_on_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Source-content drift causes a rewrite."""
+    source = tmp_path / "src"
+    install_dir = tmp_path / "sbin"
+    source.mkdir()
+    (source / "update.py").write_text("v1\n")
+    (source / "_common.py").write_text("common\n")
+    monkeypatch.setattr("install.UPDATER_INSTALL_DIR", install_dir)
+    monkeypatch.setattr("install.UPDATER_SCRIPT_PATH", install_dir / UPDATER_SCRIPT_NAME)
+    deploy_updater(source)
+    (source / "update.py").write_text("v2\n")
+    assert deploy_updater(source) is True
+    assert (install_dir / UPDATER_SCRIPT_NAME).read_text() == "v2\n"
+
+
+def test_deploy_updater_raises_when_source_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing source file fails loudly rather than silently skipping."""
+    source = tmp_path / "src"
+    install_dir = tmp_path / "sbin"
+    source.mkdir()
+    (source / "update.py").write_text("ok\n")  # _common.py intentionally missing
+    monkeypatch.setattr("install.UPDATER_INSTALL_DIR", install_dir)
+    with pytest.raises(InstallError, match="_common.py"):
+        deploy_updater(source)
+
+
+def test_invoke_updater_install_systemd_units_runs_self_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper shells out the updater with --install-systemd-units."""
+    captured: list[list[str]] = []
+    monkeypatch.setattr(
+        "install.run_command",
+        lambda argv, **kw: captured.append(list(argv)) or subprocess.CompletedProcess([], 0),
+    )
+    invoke_updater_install_systemd_units()
+    assert captured and "--install-systemd-units" in captured[0]
+    assert "minecraft-update.py" in captured[0][1]
 
 
 # --- E2E (real APIs) ---------------------------------------------------------

--- a/scripts/server/test_update.py
+++ b/scripts/server/test_update.py
@@ -1,0 +1,845 @@
+"""Unit + e2e tests for ``update.py``.
+
+Pure-logic and side-effect-free tests run by default. ``@pytest.mark.e2e`` tests hit the real PaperMC,
+Geyser, Floodgate, and Hangar APIs and are skipped unless ``pytest --run-e2e`` is passed (see
+``conftest.py`` — the flag is shared with ``test_install.py``).
+
+The flock collision test fork()s a child process to grab the lock first; this exercises the real
+``fcntl.flock`` rather than mocking it, which is the only way to verify the cross-process exclusion the
+real systemd timer relies on.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from _common import (
+    GEYSER_API_BASE,
+    DownloadError,
+    JarArtifact,
+)
+from update import (
+    ALL_COMPONENTS,
+    COMPONENT_FLOODGATE,
+    COMPONENT_GEYSER,
+    COMPONENT_PAPER,
+    COMPONENT_VIAVERSION,
+    DEFAULT_BACKUP_RETENTION,
+    DEFAULT_DATA_ROOT,
+    DEFAULT_TIMER_ONCALENDAR,
+    FLOODGATE_JAR_CANDIDATES,
+    LockAcquisitionError,
+    PaperMcVersionMismatchError,
+    ServiceRestartError,
+    UpdateError,
+    UpdatePaths,
+    acquire_lock,
+    apply_plans,
+    assert_floodgate_key_untouched,
+    assert_paper_same_mc,
+    atomic_swap,
+    build_argument_parser,
+    build_plan,
+    fetch_artifact_for,
+    install_systemd_units,
+    installed_version_for,
+    is_paper_build_newer,
+    is_semver_update_available,
+    list_backups,
+    main,
+    parse_floodgate_build_suffix,
+    parse_semver_prefix,
+    parse_trailing_dash_int,
+    prune_backups,
+    render_updater_service,
+    render_updater_timer,
+    rollback_swap,
+    staging_path_for,
+    timestamped_backup_path,
+    wait_for_tcp,
+    write_unit_if_changed,
+)
+from update import ComponentPlan, _parse_components_csv
+
+# --- parse_semver_prefix -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("2.10.0-SNAPSHOT", (2, 10, 0)),
+        ("2.2.5-SNAPSHOT (b132-5a72b6a)", (2, 2, 5)),
+        ("5.9.1", (5, 9, 1)),
+        ("1.21.8-60", (1, 21, 8)),
+        ("2.10.0-1143", (2, 10, 0)),
+        ("not-a-version", None),
+    ],
+)
+def test_parse_semver_prefix_handles_real_shapes(raw: str, expected: tuple[int, ...] | None) -> None:
+    """The three real plugin.yml shapes plus API artifact-version shapes parse to the right tuple."""
+    assert parse_semver_prefix(raw) == expected
+
+
+def test_parse_floodgate_build_suffix_pulls_b_number() -> None:
+    """The ``(b<N>-<sha>)`` suffix Floodgate writes is recognized."""
+    assert parse_floodgate_build_suffix("2.2.5-SNAPSHOT (b132-5a72b6a)") == 132
+
+
+def test_parse_floodgate_build_suffix_returns_none_when_absent() -> None:
+    """Geyser/ViaVersion plugin.yml have no ``(b<N>-...)`` suffix → ``None``."""
+    assert parse_floodgate_build_suffix("2.10.0-SNAPSHOT") is None
+    assert parse_floodgate_build_suffix("5.9.1") is None
+
+
+def test_parse_trailing_dash_int_handles_api_versions() -> None:
+    """The API artifact-version shape ``X.Y.Z-N`` exposes its trailing build N."""
+    assert parse_trailing_dash_int("1.21.8-60") == 60
+    assert parse_trailing_dash_int("2.10.0-1143") == 1143
+    assert parse_trailing_dash_int("5.9.1") is None  # no trailing -<int>
+
+
+# --- Paper version comparison ------------------------------------------------
+
+
+def test_is_paper_build_newer_simple_integer_compare() -> None:
+    """Paper update decision is simple integer comparison."""
+    assert is_paper_build_newer(58, 60) is True
+    assert is_paper_build_newer(60, 60) is False
+    assert is_paper_build_newer(60, 58) is False  # downgrade — never apply.
+
+
+def test_assert_paper_same_mc_passes_when_mc_matches() -> None:
+    """Matching MC versions allow the comparison to return."""
+    assert_paper_same_mc("1.21.8", "1.21.8")
+
+
+def test_assert_paper_same_mc_raises_on_mc_drift() -> None:
+    """Cross-MC API ``latest`` is rejected to preserve world-format compatibility."""
+    with pytest.raises(PaperMcVersionMismatchError, match="cross-MC bump"):
+        assert_paper_same_mc("1.21.8", "1.21.9")
+
+
+def test_assert_paper_same_mc_honors_max_paper_build_clamp() -> None:
+    """``--max-paper-build`` refuses higher builds even within the same MC version."""
+    with pytest.raises(PaperMcVersionMismatchError, match="exceeds --max-paper-build"):
+        assert_paper_same_mc("1.21.8", "1.21.8", max_build=60, api_build=61)
+
+
+def test_assert_paper_same_mc_permits_build_within_clamp() -> None:
+    """A build equal-to or below the clamp passes."""
+    assert_paper_same_mc("1.21.8", "1.21.8", max_build=60, api_build=60)
+
+
+# --- Geyser/Floodgate/ViaVersion version comparison -------------------------
+
+
+@pytest.mark.parametrize(
+    "installed, api, expected",
+    [
+        ("2.10.0-SNAPSHOT", "2.10.0-1143", False),  # same semver, no Floodgate build embedded → indeterminate.
+        ("2.10.0-SNAPSHOT", "2.11.0-1", True),  # API minor bumped.
+        ("2.2.5-SNAPSHOT (b132-5a72b6a)", "2.2.5-133", True),  # same semver, API build higher.
+        ("2.2.5-SNAPSHOT (b132-5a72b6a)", "2.2.5-132", False),  # same semver + same build.
+        ("2.2.5-SNAPSHOT (b132-5a72b6a)", "2.2.6-1", True),  # patch bumped.
+        ("5.9.1", "5.9.2", True),  # ViaVersion clean semver bump.
+        ("5.9.1", "5.9.1", False),  # equal.
+        ("5.10.0", "5.9.1", False),  # API somehow older — never apply.
+    ],
+)
+def test_is_semver_update_available(installed: str, api: str, expected: bool) -> None:
+    """Semver-prefix compare with Floodgate build fallback covers Geyser/Floodgate/ViaVersion."""
+    assert is_semver_update_available(installed, api) is expected
+
+
+# --- Backup naming + listing -------------------------------------------------
+
+
+def test_timestamped_backup_path_format(tmp_path: Path) -> None:
+    """Backup path is ``<jar>.YYYYMMDDTHHMMSS`` in UTC."""
+    jar = tmp_path / "paper.jar"
+    now = datetime(2026, 5, 12, 10, 30, 0, tzinfo=timezone.utc)
+    backup = timestamped_backup_path(jar, now=now)
+    assert backup == tmp_path / "paper.jar.20260512T103000"
+
+
+def test_staging_path_for_appends_new_suffix(tmp_path: Path) -> None:
+    """Staging path is ``<jar>.new`` in the same directory."""
+    jar = tmp_path / "paper.jar"
+    assert staging_path_for(jar) == tmp_path / "paper.jar.new"
+
+
+def test_list_backups_sorts_oldest_first(tmp_path: Path) -> None:
+    """Backups are returned in chronological order by timestamp lex sort."""
+    jar = tmp_path / "paper.jar"
+    jar.write_bytes(b"x")
+    for ts in ("20260512T100000", "20260511T090000", "20260513T080000"):
+        (tmp_path / f"paper.jar.{ts}").write_bytes(b"x")
+    (tmp_path / "paper.jar.partial").write_bytes(b"x")  # must NOT be picked up
+    (tmp_path / "paper.jar.new").write_bytes(b"x")  # must NOT be picked up
+    backups = list_backups(jar)
+    assert [b.name for b in backups] == [
+        "paper.jar.20260511T090000",
+        "paper.jar.20260512T100000",
+        "paper.jar.20260513T080000",
+    ]
+
+
+def test_prune_backups_keeps_newest_n(tmp_path: Path) -> None:
+    """``prune_backups`` deletes the oldest backups beyond ``retention``."""
+    jar = tmp_path / "paper.jar"
+    jar.write_bytes(b"x")
+    timestamps = ["20260510T100000", "20260511T100000", "20260512T100000", "20260513T100000"]
+    for ts in timestamps:
+        (tmp_path / f"paper.jar.{ts}").write_bytes(b"x")
+    removed = prune_backups(jar, retention=2)
+    remaining = sorted(p.name for p in tmp_path.glob("paper.jar.*"))
+    assert sorted(r.name for r in removed) == ["paper.jar.20260510T100000", "paper.jar.20260511T100000"]
+    assert remaining == ["paper.jar.20260512T100000", "paper.jar.20260513T100000"]
+
+
+def test_prune_backups_is_noop_when_under_retention(tmp_path: Path) -> None:
+    """No backups are deleted when count <= retention."""
+    jar = tmp_path / "paper.jar"
+    jar.write_bytes(b"x")
+    (tmp_path / "paper.jar.20260510T100000").write_bytes(b"x")
+    removed = prune_backups(jar, retention=3)
+    assert removed == []
+
+
+# --- Atomic swap + rollback simulation --------------------------------------
+
+
+def test_atomic_swap_leaves_backup_and_chowns_new(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The swap creates a timestamped backup and chowns the swapped-in jar."""
+    jar = tmp_path / "paper.jar"
+    jar.write_bytes(b"old-paper-bytes")
+    staging = tmp_path / "paper.jar.new"
+    staging.write_bytes(b"new-paper-bytes")
+    chown_calls: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        chown_calls.append(list(argv))
+        return subprocess.CompletedProcess(args=list(argv), returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("update.subprocess.run", fake_run)
+    now = datetime(2026, 5, 12, 4, 0, 0, tzinfo=timezone.utc)
+    backup = atomic_swap(jar, staging, owner_user="minecraft", owner_group="minecraft", now=now)
+    assert jar.read_bytes() == b"new-paper-bytes"
+    assert backup.read_bytes() == b"old-paper-bytes"
+    assert not staging.exists()
+    assert chown_calls and chown_calls[0][:2] == ["chown", "minecraft:minecraft"]
+
+
+def test_rollback_swap_restores_previous_jar(tmp_path: Path) -> None:
+    """Rolling back moves the (suspect) jar aside and restores the backup into place."""
+    jar = tmp_path / "paper.jar"
+    backup = tmp_path / "paper.jar.20260512T040000"
+    jar.write_bytes(b"suspect-new")
+    backup.write_bytes(b"trusted-old")
+    rollback_swap(jar, backup)
+    assert jar.read_bytes() == b"trusted-old"
+    assert not backup.exists()
+    suspects = sorted(p.name for p in tmp_path.iterdir() if p.name.startswith("paper.jar.failed."))
+    assert len(suspects) == 1
+
+
+# --- Lock-file collision ----------------------------------------------------
+
+
+def test_acquire_lock_succeeds_when_uncontended(tmp_path: Path) -> None:
+    """First-acquisition path works and writes the PID."""
+    lock = tmp_path / "lock"
+    handle = acquire_lock(lock)
+    assert lock.exists()
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    handle.close()
+
+
+def test_acquire_lock_refuses_when_held(tmp_path: Path) -> None:
+    """A second acquisition while the first is held raises LockAcquisitionError.
+
+    We hold the lock via fork() so the OS sees two independent processes — that's the real-world
+    scenario (manual run + systemd timer firing simultaneously). Same-process flock with the same fd
+    does not block, so we cannot exercise this within a single Python process.
+    """
+    lock = tmp_path / "lock"
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        os.close(read_fd)
+        try:
+            handle = acquire_lock(lock)
+            os.write(write_fd, b"locked\n")
+            time.sleep(0.5)
+            handle.close()
+        finally:
+            os._exit(0)
+    os.close(write_fd)
+    try:
+        assert os.read(read_fd, 32) == b"locked\n"
+        with pytest.raises(LockAcquisitionError):
+            acquire_lock(lock)
+    finally:
+        os.close(read_fd)
+        os.waitpid(pid, 0)
+
+
+# --- build_plan: decides apply / skip / missing -----------------------------
+
+
+def _make_paths(tmp_path: Path) -> UpdatePaths:
+    """Build an ``UpdatePaths`` rooted at ``tmp_path`` and pre-create the dirs."""
+    paths = UpdatePaths.from_data_root(tmp_path)
+    paths.server_dir.mkdir(parents=True, exist_ok=True)
+    paths.plugins_dir.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+def _write_paper_history(paths: UpdatePaths, mc: str, build: int) -> None:
+    """Stub Paper's version_history.json in the server dir."""
+    (paths.server_dir / "version_history.json").write_text(
+        f'{{"currentVersion": "git-Paper-{build} (MC: {mc})"}}', encoding="utf-8"
+    )
+
+
+def test_build_plan_skips_when_sha_matches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the on-disk jar's sha matches the API's, the component plans ``skip``."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"current-geyser-bytes")
+    matching_sha = hashlib.sha256(b"current-geyser-bytes").hexdigest()
+    artifact = JarArtifact(
+        label="geyser",
+        version="2.10.0-1143",
+        download_url="https://example/g.jar",
+        sha256=matching_sha,
+        filename="Geyser-Spigot.jar",
+    )
+    monkeypatch.setattr("update.fetch_artifact_for", lambda comp, overrides: artifact)
+    monkeypatch.setattr("update.read_plugin_version", lambda j: "2.10.0-SNAPSHOT")
+    plans = build_plan([COMPONENT_GEYSER], paths, {}, force=False)
+    assert len(plans) == 1
+    assert plans[0].action == "skip"
+
+
+def test_build_plan_applies_when_sha_differs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """sha mismatch flips the component to ``apply``."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"old-geyser-bytes")
+    artifact = JarArtifact(
+        label="geyser",
+        version="2.10.0-1143",
+        download_url="https://example/g.jar",
+        sha256="ff" * 32,
+        filename="Geyser-Spigot.jar",
+    )
+    monkeypatch.setattr("update.fetch_artifact_for", lambda comp, overrides: artifact)
+    monkeypatch.setattr("update.read_plugin_version", lambda j: "2.10.0-SNAPSHOT")
+    plans = build_plan([COMPONENT_GEYSER], paths, {}, force=False)
+    assert plans[0].action == "apply"
+
+
+def test_build_plan_force_applies_even_when_sha_matches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--force`` overrides the sha match."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"current")
+    matching_sha = hashlib.sha256(b"current").hexdigest()
+    artifact = JarArtifact(
+        label="geyser",
+        version="2.10.0-1143",
+        download_url="https://example/g.jar",
+        sha256=matching_sha,
+        filename="Geyser-Spigot.jar",
+    )
+    monkeypatch.setattr("update.fetch_artifact_for", lambda comp, overrides: artifact)
+    monkeypatch.setattr("update.read_plugin_version", lambda j: "2.10.0-SNAPSHOT")
+    plans = build_plan([COMPONENT_GEYSER], paths, {}, force=True)
+    assert plans[0].action == "apply"
+
+
+def test_build_plan_marks_missing_when_jar_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A component with no installed jar is flagged ``missing`` (install.py's job to place)."""
+    paths = _make_paths(tmp_path)
+    artifact = JarArtifact(
+        label="geyser",
+        version="2.10.0-1143",
+        download_url="https://example/g.jar",
+        sha256="ff" * 32,
+        filename="Geyser-Spigot.jar",
+    )
+    monkeypatch.setattr("update.fetch_artifact_for", lambda comp, overrides: artifact)
+    plans = build_plan([COMPONENT_GEYSER], paths, {}, force=False)
+    assert plans[0].action == "missing"
+
+
+def test_build_plan_paper_clamp_rejects_cross_mc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Paper plan halts when the API's latest is for a different MC version."""
+    paths = _make_paths(tmp_path)
+    paths.paper_jar.write_bytes(b"paper-1.21.8-58")
+    _write_paper_history(paths, "1.21.8", 58)
+    # API returns a Paper build for 1.21.9 — the function calls assert_paper_same_mc with installed_mc
+    # for BOTH inputs (the installed MC is the only allowed MC for the URL). But the artifact's version
+    # might still report a different stream; the clamp is enforced via the call shape. To verify the
+    # clamp behavior, we directly exercise assert_paper_same_mc above. Here, just verify the plan
+    # call succeeds when the API is on the same MC.
+    artifact = JarArtifact(
+        label="paper",
+        version="1.21.8-60",
+        download_url="https://example/p.jar",
+        sha256="ee" * 32,
+        filename="paper-1.21.8-60.jar",
+    )
+
+    def fake_fetch(component: str, overrides: dict) -> JarArtifact:
+        assert overrides.get("paper_mc_version") == "1.21.8"
+        return artifact
+
+    monkeypatch.setattr("update.fetch_artifact_for", fake_fetch)
+    plans = build_plan([COMPONENT_PAPER], paths, {}, force=False)
+    assert plans[0].action == "apply"
+    assert plans[0].artifact.version == "1.21.8-60"
+
+
+def test_build_plan_paper_skipped_when_no_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No version_history.json yet (fresh install) → Paper is skipped, not errored."""
+    paths = _make_paths(tmp_path)
+    # No history file written. fetch should never be called for paper.
+    called = mock.Mock()
+    monkeypatch.setattr("update.fetch_artifact_for", called)
+    plans = build_plan([COMPONENT_PAPER], paths, {}, force=False)
+    assert plans == []
+    called.assert_not_called()
+
+
+def test_build_plan_paper_max_build_clamp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--max-paper-build`` halts the run if API's latest exceeds the clamp."""
+    paths = _make_paths(tmp_path)
+    paths.paper_jar.write_bytes(b"paper-1.21.8-58")
+    _write_paper_history(paths, "1.21.8", 58)
+    artifact = JarArtifact(
+        label="paper",
+        version="1.21.8-99",
+        download_url="https://example/p.jar",
+        sha256="ee" * 32,
+        filename="paper-1.21.8-99.jar",
+    )
+    monkeypatch.setattr("update.fetch_artifact_for", lambda comp, overrides: artifact)
+    with pytest.raises(PaperMcVersionMismatchError, match="exceeds --max-paper-build"):
+        build_plan([COMPONENT_PAPER], paths, {"max_paper_build": 60}, force=False)
+
+
+# --- apply_plans: end-to-end swap + rollback --------------------------------
+
+
+def test_apply_plans_skip_action_does_not_download(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A ``skip`` plan performs no IO."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"current")
+    download_called = mock.Mock()
+    monkeypatch.setattr("update.http_download_to_file", download_called)
+    monkeypatch.setattr("update.restart_and_verify", mock.Mock())
+    plan = ComponentPlan(
+        component=COMPONENT_GEYSER,
+        installed_version="2.10.0-SNAPSHOT",
+        installed_sha256="aa" * 32,
+        artifact=JarArtifact("geyser", "2.10.0-1143", "https://example/g.jar", "aa" * 32, "Geyser-Spigot.jar"),
+        action="skip",
+    )
+    result = apply_plans(
+        [plan],
+        paths,
+        owner_user="u",
+        owner_group="g",
+        no_restart=False,
+        skip_probe=True,
+        retention=DEFAULT_BACKUP_RETENTION,
+        dry_run=False,
+    )
+    assert result == 0
+    download_called.assert_not_called()
+
+
+def test_apply_plans_downloads_swaps_and_restarts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The happy-path apply downloads, sha-verifies, swaps, restarts, prunes."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"old-geyser")
+    new_bytes = b"new-geyser-bytes"
+    new_sha = hashlib.sha256(new_bytes).hexdigest()
+
+    def fake_download(url, dest):
+        dest.write_bytes(new_bytes)
+
+    monkeypatch.setattr("update.http_download_to_file", fake_download)
+    monkeypatch.setattr("update.subprocess.run", lambda *a, **kw: subprocess.CompletedProcess([], 0))
+    restart = mock.Mock()
+    monkeypatch.setattr("update.restart_and_verify", restart)
+
+    plan = ComponentPlan(
+        component=COMPONENT_GEYSER,
+        installed_version="2.10.0-SNAPSHOT",
+        installed_sha256="aa" * 32,
+        artifact=JarArtifact("geyser", "2.10.0-1143", "https://example/g.jar", new_sha, "Geyser-Spigot.jar"),
+        action="apply",
+    )
+    now = datetime(2026, 5, 12, 10, 0, 0, tzinfo=timezone.utc)
+    result = apply_plans(
+        [plan],
+        paths,
+        owner_user="u",
+        owner_group="g",
+        no_restart=False,
+        skip_probe=True,
+        retention=DEFAULT_BACKUP_RETENTION,
+        dry_run=False,
+        now=now,
+    )
+    assert result == 1
+    assert paths.jar_for(COMPONENT_GEYSER).read_bytes() == new_bytes
+    backup = paths.plugins_dir / "Geyser-Spigot.jar.20260512T100000"
+    assert backup.read_bytes() == b"old-geyser"
+    restart.assert_called_once()
+
+
+def test_apply_plans_rolls_back_on_restart_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Restart failure after swap rolls every swapped jar back and surfaces ServiceRestartError."""
+    paths = _make_paths(tmp_path)
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"old-geyser")
+    new_bytes = b"new-geyser"
+    new_sha = hashlib.sha256(new_bytes).hexdigest()
+
+    def fake_download(url, dest):
+        dest.write_bytes(new_bytes)
+
+    monkeypatch.setattr("update.http_download_to_file", fake_download)
+    monkeypatch.setattr("update.subprocess.run", lambda *a, **kw: subprocess.CompletedProcess([], 0))
+    calls: list[bool] = []
+
+    def restart_then_fail(*, skip_probe: bool, dry_run: bool):
+        calls.append(skip_probe)
+        if len(calls) == 1:
+            raise ServiceRestartError("simulated bad bind")
+        # The post-rollback restart attempt — succeed silently.
+
+    monkeypatch.setattr("update.restart_and_verify", restart_then_fail)
+
+    plan = ComponentPlan(
+        component=COMPONENT_GEYSER,
+        installed_version="2.10.0-SNAPSHOT",
+        installed_sha256="aa" * 32,
+        artifact=JarArtifact("geyser", "2.10.0-1143", "https://example/g.jar", new_sha, "Geyser-Spigot.jar"),
+        action="apply",
+    )
+
+    with pytest.raises(ServiceRestartError, match="simulated bad bind"):
+        apply_plans(
+            [plan],
+            paths,
+            owner_user="u",
+            owner_group="g",
+            no_restart=False,
+            skip_probe=True,
+            retention=DEFAULT_BACKUP_RETENTION,
+            dry_run=False,
+        )
+
+    # The original bytes are restored.
+    assert paths.jar_for(COMPONENT_GEYSER).read_bytes() == b"old-geyser"
+    # A .failed.<ts> sibling tracks the bad jar.
+    assert list(paths.plugins_dir.glob("Geyser-Spigot.jar.failed.*"))
+    # The post-rollback restart was attempted with skip_probe=True.
+    assert calls == [True, True]
+
+
+def test_apply_plans_floodgate_key_untouched(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Floodgate key on disk is untouched by a happy-path apply."""
+    paths = _make_paths(tmp_path)
+    paths.floodgate_key.parent.mkdir(parents=True, exist_ok=True)
+    paths.floodgate_key.write_bytes(b"pem-bytes")
+    key_sha_before = hashlib.sha256(b"pem-bytes").hexdigest()
+    paths.jar_for(COMPONENT_GEYSER).write_bytes(b"old")
+    new_bytes = b"new"
+    new_sha = hashlib.sha256(new_bytes).hexdigest()
+
+    def fake_download(url, dest):
+        dest.write_bytes(new_bytes)
+
+    monkeypatch.setattr("update.http_download_to_file", fake_download)
+    monkeypatch.setattr("update.subprocess.run", lambda *a, **kw: subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr("update.restart_and_verify", mock.Mock())
+
+    plan = ComponentPlan(
+        component=COMPONENT_GEYSER,
+        installed_version="2.10.0-SNAPSHOT",
+        installed_sha256="aa" * 32,
+        artifact=JarArtifact("geyser", "2.10.0-1143", "https://example/g.jar", new_sha, "Geyser-Spigot.jar"),
+        action="apply",
+    )
+    apply_plans(
+        [plan],
+        paths,
+        owner_user="u",
+        owner_group="g",
+        no_restart=False,
+        skip_probe=True,
+        retention=DEFAULT_BACKUP_RETENTION,
+        dry_run=False,
+    )
+    assert paths.floodgate_key.read_bytes() == b"pem-bytes"
+    assert hashlib.sha256(paths.floodgate_key.read_bytes()).hexdigest() == key_sha_before
+
+
+def test_assert_floodgate_key_untouched_raises_on_drift(tmp_path: Path) -> None:
+    """If the key's hash drifts mid-run, the invariant fires."""
+    paths = _make_paths(tmp_path)
+    paths.floodgate_key.parent.mkdir(parents=True, exist_ok=True)
+    paths.floodgate_key.write_bytes(b"new-content")
+    with pytest.raises(UpdateError, match="INVARIANT VIOLATED"):
+        assert_floodgate_key_untouched(paths, sha_before="a" * 64)
+
+
+# --- jar_for candidate-name fallback ----------------------------------------
+
+
+def test_jar_for_floodgate_finds_capital_f_variant(tmp_path: Path) -> None:
+    """When the live host has ``Floodgate-Spigot.jar`` (operator-renamed), jar_for finds it."""
+    paths = _make_paths(tmp_path)
+    capital = paths.plugins_dir / "Floodgate-Spigot.jar"
+    capital.write_bytes(b"floodgate-bytes")
+    assert paths.jar_for(COMPONENT_FLOODGATE) == capital
+
+
+def test_jar_for_floodgate_finds_lowercase_default(tmp_path: Path) -> None:
+    """A fresh install.py-style ``floodgate-spigot.jar`` is also picked up.
+
+    Skipped on case-insensitive filesystems (macOS APFS default) because the test relies on the
+    filesystem distinguishing ``Floodgate-Spigot.jar`` from ``floodgate-spigot.jar``.
+    """
+    probe_upper = tmp_path / "CASE-PROBE"
+    probe_upper.write_bytes(b"x")
+    if (tmp_path / "case-probe").exists():
+        pytest.skip("filesystem is case-insensitive; live-host Linux FS is case-sensitive")
+    paths = _make_paths(tmp_path)
+    lower = paths.plugins_dir / "floodgate-spigot.jar"
+    lower.write_bytes(b"floodgate-bytes")
+    assert paths.jar_for(COMPONENT_FLOODGATE) == lower
+
+
+def test_jar_for_floodgate_prefers_first_candidate_when_neither_exists(tmp_path: Path) -> None:
+    """No installed jar — fall back to the canonical name so the path is well-defined for ``missing``."""
+    paths = _make_paths(tmp_path)
+    expected = paths.plugins_dir / FLOODGATE_JAR_CANDIDATES[0]
+    assert paths.jar_for(COMPONENT_FLOODGATE) == expected
+
+
+# --- wait_for_tcp polling ---------------------------------------------------
+
+
+def test_wait_for_tcp_succeeds_after_a_few_attempts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``wait_for_tcp`` polls until ``tcp_probe`` returns True, not just one shot."""
+    calls = {"count": 0}
+
+    def fake_probe(*_args, **_kwargs):
+        calls["count"] += 1
+        return calls["count"] >= 3
+
+    monkeypatch.setattr("update.tcp_probe", fake_probe)
+    monkeypatch.setattr("update.time.sleep", lambda _s: None)
+    assert wait_for_tcp(total_window_s=60, poll_interval_s=1) is True
+    assert calls["count"] == 3
+
+
+def test_wait_for_tcp_returns_false_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``tcp_probe`` never succeeds inside the window, wait_for_tcp returns False."""
+    monkeypatch.setattr("update.tcp_probe", lambda *a, **kw: False)
+    monkeypatch.setattr("update.time.sleep", lambda _s: None)
+    # monotonic ticks past the deadline after a few invocations to short-circuit the loop.
+    ticks = iter([0.0, 0.1, 0.2, 999.0])
+    monkeypatch.setattr("update.time.monotonic", lambda: next(ticks))
+    assert wait_for_tcp(total_window_s=10, poll_interval_s=1) is False
+
+
+# --- --install-systemd-units idempotency ------------------------------------
+
+
+def test_install_systemd_units_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """First run writes units + daemon-reload + enable; second run is a no-op except enable."""
+    service = tmp_path / "minecraft-update.service"
+    timer = tmp_path / "minecraft-update.timer"
+    runs: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        runs.append(list(argv))
+        return subprocess.CompletedProcess(args=list(argv), returncode=0)
+
+    monkeypatch.setattr("update.subprocess.run", fake_run)
+
+    rc = install_systemd_units(
+        service_path=service,
+        timer_path=timer,
+        dry_run=False,
+    )
+    assert rc == 0
+    assert service.exists() and timer.exists()
+    # First run: daemon-reload + enable --now.
+    assert ["systemctl", "daemon-reload"] in runs
+    assert any(cmd[:3] == ["systemctl", "enable", "--now"] for cmd in runs)
+
+    runs.clear()
+    install_systemd_units(service_path=service, timer_path=timer, dry_run=False)
+    # Second run: enable only — no daemon-reload (content didn't change).
+    assert ["systemctl", "daemon-reload"] not in runs
+    assert any(cmd[:3] == ["systemctl", "enable", "--now"] for cmd in runs)
+
+
+def test_render_updater_timer_uses_10utc_default() -> None:
+    """The default timer fires at 10:00 UTC with randomized delay."""
+    content = render_updater_timer()
+    assert "OnCalendar=*-*-* 10:00:00 UTC" in content
+    assert "RandomizedDelaySec=3600" in content
+    assert "Persistent=true" in content
+
+
+def test_render_updater_service_uses_root_oneshot() -> None:
+    """The service runs as root, Type=oneshot."""
+    content = render_updater_service()
+    assert "User=root" in content
+    assert "Type=oneshot" in content
+    assert "ExecStart=/usr/local/sbin/minecraft-update.py" in content
+
+
+def test_write_unit_if_changed_writes_only_on_drift(tmp_path: Path) -> None:
+    """Identical content is a no-op (no rewrite)."""
+    path = tmp_path / "u.service"
+    assert write_unit_if_changed(path, "body\n") is True
+    assert write_unit_if_changed(path, "body\n") is False
+    assert write_unit_if_changed(path, "body changed\n") is True
+
+
+# --- Argument parser ---------------------------------------------------------
+
+
+def test_argument_parser_defaults() -> None:
+    """Defaults match the documented constants."""
+    parser = build_argument_parser()
+    args = parser.parse_args([])
+    assert args.data_root == DEFAULT_DATA_ROOT
+    assert args.components is None  # → ALL_COMPONENTS in update()
+    assert args.keep_backups == DEFAULT_BACKUP_RETENTION
+    assert args.force is False
+    assert args.dry_run is False
+    assert args.install_systemd_units is False
+    assert args.timer_oncalendar == DEFAULT_TIMER_ONCALENDAR
+
+
+def test_parse_components_csv_accepts_subset() -> None:
+    """``geyser,floodgate`` parses to a valid subset."""
+    assert _parse_components_csv("geyser,floodgate") == ["geyser", "floodgate"]
+
+
+def test_parse_components_csv_rejects_unknown() -> None:
+    """Unknown identifiers raise a CLI error."""
+    with pytest.raises(argparse.ArgumentTypeError, match="unknown component"):
+        _parse_components_csv("geyser,nonsense")
+
+
+# --- main() error mapping ---------------------------------------------------
+
+
+def test_main_returns_zero_on_install_systemd_units(monkeypatch: pytest.MonkeyPatch) -> None:
+    """--install-systemd-units path returns 0 on success."""
+    monkeypatch.setattr("update.install_systemd_units", lambda **kw: 0)
+    assert main(["--install-systemd-units"]) == 0
+
+
+def test_update_returns_zero_when_components_swapped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful run with N applied updates returns 0, not N.
+
+    Regression: an earlier version of ``update()`` propagated ``apply_plans``'s count as its return
+    value, so a run that swapped 3 jars exited 3 → systemd reported the timer-fired service as failed
+    despite every step succeeding.
+    """
+    monkeypatch.setattr("update.assert_root", lambda: None)
+    monkeypatch.setattr("update.acquire_lock", lambda _p: open(tmp_path / "lock", "w"))
+    monkeypatch.setattr("update.build_plan", lambda *a, **kw: [])
+    monkeypatch.setattr("update.apply_plans", lambda *a, **kw: 3)
+    args = build_argument_parser().parse_args(["--data-root", str(tmp_path)])
+    from update import update as run_update
+
+    assert run_update(args) == 0
+
+
+def test_main_returns_two_on_paper_clamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """PaperMcVersionMismatchError maps to exit code 2."""
+
+    def boom(_args):
+        raise PaperMcVersionMismatchError("cross-mc")
+
+    monkeypatch.setattr("update.update", boom)
+    assert main([]) == 2
+
+
+def test_main_returns_three_on_download_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DownloadError maps to exit code 3."""
+
+    def boom(_args):
+        raise DownloadError("network down")
+
+    monkeypatch.setattr("update.update", boom)
+    assert main([]) == 3
+
+
+def test_main_returns_four_on_restart_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ServiceRestartError maps to exit code 4."""
+
+    def boom(_args):
+        raise ServiceRestartError("did not bind")
+
+    monkeypatch.setattr("update.update", boom)
+    assert main([]) == 4
+
+
+# --- E2E (real APIs) --------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_e2e_geyser_artifact_round_trip() -> None:
+    """fetch_artifact_for(geyser) hits the real API and returns a downloadable artifact."""
+    art = fetch_artifact_for(COMPONENT_GEYSER, {})
+    assert art.sha256 and len(art.sha256) == 64
+    assert art.download_url.startswith("https://")
+
+
+@pytest.mark.e2e
+def test_e2e_floodgate_artifact_round_trip() -> None:
+    """fetch_artifact_for(floodgate) hits the real API."""
+    art = fetch_artifact_for(COMPONENT_FLOODGATE, {})
+    assert art.sha256 and len(art.sha256) == 64
+    assert "floodgate" in art.filename.lower()
+
+
+@pytest.mark.e2e
+def test_e2e_viaversion_artifact_round_trip() -> None:
+    """fetch_artifact_for(viaversion) hits the real Hangar API."""
+    art = fetch_artifact_for(COMPONENT_VIAVERSION, {})
+    assert art.sha256 and len(art.sha256) == 64
+    assert art.filename == "ViaVersion.jar"
+
+
+@pytest.mark.e2e
+def test_e2e_paper_artifact_round_trip() -> None:
+    """fetch_artifact_for(paper) needs the MC override; uses 1.21.8 as the canonical pin."""
+    art = fetch_artifact_for(COMPONENT_PAPER, {"paper_mc_version": "1.21.8"})
+    assert art.sha256 and len(art.sha256) == 64
+    assert art.version.startswith("1.21.8-")

--- a/scripts/server/update.py
+++ b/scripts/server/update.py
@@ -1,0 +1,1338 @@
+#!/usr/bin/env python3
+"""Idempotent nightly updater for Paper + Geyser + Floodgate + ViaVersion.
+
+Invocation (run on the live host as root, normally via the ``minecraft-update.timer`` systemd timer)::
+
+    sudo /usr/local/sbin/minecraft-update.py
+    sudo /usr/local/sbin/minecraft-update.py --dry-run
+    sudo /usr/local/sbin/minecraft-update.py --components geyser,floodgate
+    sudo /usr/local/sbin/minecraft-update.py --install-systemd-units
+
+This script is the follow-up the install-time provisioner (``install.py``) explicitly deferred. Its raison
+d'être is **Bedrock client connectivity preservation**: when Mojang ships a Bedrock client update (every 2–6
+weeks, auto-rolled to every console / mobile player within hours), the server-side Geyser jar must move to
+the matching protocol or every Bedrock player sees "Unable to connect to world" with no recourse. Java
+players are unaffected.
+
+Priority order, hardest to softest:
+
+1. Geyser — connectivity-critical, ship aggressively on the version stream the API publishes.
+2. Floodgate — track Geyser; the two share API surfaces and want to bump in lockstep.
+3. Paper — patch-level only. **MC-version bumps are out of scope.** The updater clamps Paper to the running
+   MC version's build stream and refuses to cross. To move MC versions, the operator re-runs ``install.py``
+   with ``--mc-version``.
+4. ViaVersion — track the latest Release-channel build from Hangar.
+
+CRITICAL invariants:
+
+- ``plugins/floodgate/key.pem`` is **never touched**. Same hard guarantee as ``install.py``; regenerating
+  the key breaks Bedrock auth for every existing player.
+- Paper is never bumped across MC versions, regardless of what the API reports as ``latest``.
+- Every download is sha256-verified against the API's reported hash before being placed.
+- On any failure mid-update (checksum miss, post-restart probe failure, etc.), the previous jar(s) are
+  restored from timestamped backups and the service is restarted on the rollback.
+
+The flow is sha256-driven: read the API's reported sha256, compare against the on-disk jar's hash, and only
+swap when they differ. The version-comparison helpers exist primarily for human-readable log lines and the
+Paper MC-version clamp; the actual update decision rides on the sha mismatch.
+
+Stdlib only — the script runs as root under systemd with no pip available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from _common import (
+    FLOODGATE_API_BASE,
+    GEYSER_API_BASE,
+    ChecksumMismatchError,
+    DownloadError,
+    JarArtifact,
+    fetch_geyser_like_artifact,
+    fetch_paper_artifact,
+    fetch_viaversion_artifact,
+    http_download_to_file,
+    read_mc_version_from_history,
+    read_plugin_version,
+    sha256_of_file,
+)
+
+# --- Constants ---------------------------------------------------------------
+
+DEFAULT_DATA_ROOT = Path("/srv/minecraft")
+SERVER_SUBDIR = "server"
+PLUGINS_SUBDIR = "plugins"
+PAPER_JAR_NAME = "paper.jar"
+
+# Plugin jar filenames in operator-preference order. The first existing match wins on disk; when no
+# candidate exists, the first entry is treated as the canonical "fresh install" filename. Floodgate
+# carries two candidates because the upstream-default ``floodgate-spigot.jar`` and the
+# operator-renamed ``Floodgate-Spigot.jar`` (case-matched to Geyser-Spigot.jar) both occur in the
+# wild — the live host this repo targets uses the capital-F variant.
+GEYSER_JAR_CANDIDATES: tuple[str, ...] = ("Geyser-Spigot.jar",)
+FLOODGATE_JAR_CANDIDATES: tuple[str, ...] = ("Floodgate-Spigot.jar", "floodgate-spigot.jar")
+VIAVERSION_JAR_CANDIDATES: tuple[str, ...] = ("ViaVersion.jar",)
+
+DEFAULT_USER = "minecraft"
+DEFAULT_GROUP = "minecraft"
+
+DEFAULT_LOCK_PATH = Path("/run/minecraft-update.lock")
+DEFAULT_BACKUP_RETENTION = 3
+
+MINECRAFT_SERVICE_NAME = "minecraft.service"
+RESTART_WAIT_TIMEOUT_S = 120
+RESTART_POLL_INTERVAL_S = 2
+TCP_PROBE_HOST = "127.0.0.1"
+TCP_PROBE_PORT = 25565
+TCP_PROBE_TIMEOUT_S = 5
+TCP_PROBE_GRACE_S = 5
+# Paper's cold-restart binds 25565 well after systemd's ``is-active`` flips to active — Type=simple
+# only requires the JVM to be running, not for the server to be accepting connections. Empirically
+# 20–60s from restart to bind. Poll up to 180s total so even a heavy-world load completes inside the
+# window. Anything slower than 180s is a real outage, not a slow boot.
+TCP_PROBE_TOTAL_WINDOW_S = 180
+TCP_PROBE_POLL_INTERVAL_S = 3
+
+UPDATER_SERVICE_PATH = Path("/etc/systemd/system/minecraft-update.service")
+UPDATER_TIMER_PATH = Path("/etc/systemd/system/minecraft-update.timer")
+UPDATER_TIMER_NAME = "minecraft-update.timer"
+UPDATER_SCRIPT_INSTALL_PATH = Path("/usr/local/sbin/minecraft-update.py")
+
+# 10:00 UTC = ~5 AM CDT / 4 AM CST — genuine off-peak for the player base.
+# DO NOT default to 04:00 UTC: that's ~11 PM CDT (peak late-night gaming).
+DEFAULT_TIMER_ONCALENDAR = "*-*-* 10:00:00 UTC"
+DEFAULT_TIMER_RANDOMIZED_DELAY = "3600"
+
+UPDATER_SERVICE_TEMPLATE = """\
+[Unit]
+Description=Minecraft Paper + plugins updater (Geyser / Floodgate / Paper / ViaVersion)
+Documentation=https://github.com/brandonavant/aws-hosted-minecraft
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart={script_path}
+User=root
+"""
+
+UPDATER_TIMER_TEMPLATE = """\
+[Unit]
+Description=Run minecraft-update.service daily during off-peak hours
+Documentation=https://github.com/brandonavant/aws-hosted-minecraft
+
+[Timer]
+OnCalendar={oncalendar}
+RandomizedDelaySec={randomized_delay}
+Persistent=true
+Unit=minecraft-update.service
+
+[Install]
+WantedBy=timers.target
+"""
+
+# Component identifiers. Order matters for the apply phase — Geyser first because it's the
+# connectivity-critical bump; Floodgate immediately after (they share auth state). Paper and ViaVersion
+# can move in either order.
+COMPONENT_GEYSER = "geyser"
+COMPONENT_FLOODGATE = "floodgate"
+COMPONENT_PAPER = "paper"
+COMPONENT_VIAVERSION = "viaversion"
+ALL_COMPONENTS: tuple[str, ...] = (COMPONENT_GEYSER, COMPONENT_FLOODGATE, COMPONENT_PAPER, COMPONENT_VIAVERSION)
+
+BACKUP_TIMESTAMP_FORMAT = "%Y%m%dT%H%M%S"
+_BACKUP_TIMESTAMP_RE = re.compile(r"\.(\d{8}T\d{6})$")
+_SEMVER_PREFIX_RE = re.compile(r"^(\d+(?:\.\d+)*)")
+_FLOODGATE_BUILD_RE = re.compile(r"\(b(\d+)-")
+_TRAILING_DASH_INT_RE = re.compile(r"-(\d+)$")
+
+
+# --- Exceptions --------------------------------------------------------------
+
+
+class UpdateError(RuntimeError):
+    """Base class for updater errors. Caught at the CLI boundary."""
+
+
+class PreflightError(UpdateError):
+    """Raised when a pre-flight assertion fails (root, lock)."""
+
+
+class PaperMcVersionMismatchError(UpdateError):
+    """Raised when the API's latest Paper build is for a different MC version than the running one."""
+
+
+class ServiceRestartError(UpdateError):
+    """Raised when systemctl restart or the post-restart probe fails."""
+
+
+class LockAcquisitionError(UpdateError):
+    """Raised when the lock file is held by another updater run."""
+
+
+# --- Datatypes ---------------------------------------------------------------
+
+
+_PLUGIN_JAR_CANDIDATES: dict[str, tuple[str, ...]] = {
+    COMPONENT_GEYSER: GEYSER_JAR_CANDIDATES,
+    COMPONENT_FLOODGATE: FLOODGATE_JAR_CANDIDATES,
+    COMPONENT_VIAVERSION: VIAVERSION_JAR_CANDIDATES,
+}
+
+
+@dataclass(frozen=True)
+class UpdatePaths:
+    """Resolved on-disk locations the updater operates against.
+
+    Attributes:
+        data_root: Mountpoint of the data volume (default ``/srv/minecraft``).
+        server_dir: Paper server directory.
+        plugins_dir: Plugins directory.
+        paper_jar: Paper jar path (always ``<server_dir>/paper.jar`` — install.py renames on placement).
+        floodgate_key: ``plugins/floodgate/key.pem`` — read-only invariant: NEVER touched by the updater.
+    """
+
+    data_root: Path
+    server_dir: Path
+    plugins_dir: Path
+    paper_jar: Path
+    floodgate_key: Path
+
+    @classmethod
+    def from_data_root(cls, data_root: Path) -> "UpdatePaths":
+        """Build an ``UpdatePaths`` from the volume root.
+
+        Args:
+            data_root: Mountpoint of the data volume.
+
+        Returns:
+            A fully-populated ``UpdatePaths``.
+        """
+        server_dir = data_root / SERVER_SUBDIR
+        plugins_dir = server_dir / PLUGINS_SUBDIR
+        return cls(
+            data_root=data_root,
+            server_dir=server_dir,
+            plugins_dir=plugins_dir,
+            paper_jar=server_dir / PAPER_JAR_NAME,
+            floodgate_key=plugins_dir / "floodgate" / "key.pem",
+        )
+
+    def jar_for(self, component: str) -> Path:
+        """Return the on-disk jar path for ``component``.
+
+        For plugins, picks the first candidate filename that exists on disk; falls back to the first
+        candidate (the canonical fresh-install name) when none exist, so the path is still well-defined
+        for the ``"missing"`` plan branch.
+
+        Args:
+            component: One of ``COMPONENT_*`` identifiers.
+
+        Returns:
+            The jar's absolute path.
+
+        Raises:
+            ValueError: When ``component`` is unrecognized.
+        """
+        if component == COMPONENT_PAPER:
+            return self.paper_jar
+        candidates = _PLUGIN_JAR_CANDIDATES.get(component)
+        if candidates is None:
+            raise ValueError(f"unknown component {component!r}")
+        for name in candidates:
+            candidate_path = self.plugins_dir / name
+            if candidate_path.exists():
+                return candidate_path
+        return self.plugins_dir / candidates[0]
+
+
+@dataclass(frozen=True)
+class ComponentPlan:
+    """One component's update plan for this run.
+
+    Attributes:
+        component: Component identifier.
+        installed_version: Human-readable installed version string for log lines (e.g. ``"1.21.8-58"``,
+            ``"2.10.0-SNAPSHOT"``). ``None`` when no installed jar exists or version is unreadable.
+        installed_sha256: sha256 hex digest of the installed jar, or ``None`` when no jar exists.
+        artifact: API-reported latest artifact metadata.
+        action: ``"apply"`` (sha differs), ``"skip"`` (sha matches), or ``"missing"`` (no installed jar —
+            covered by ``install.py``, skipped here with a warning).
+    """
+
+    component: str
+    installed_version: str | None
+    installed_sha256: str | None
+    artifact: JarArtifact
+    action: str
+
+
+# --- Logging -----------------------------------------------------------------
+
+
+def log(message: str) -> None:
+    """Emit a single log line to stdout (systemd journals via the service unit).
+
+    Args:
+        message: The line to print. Newline appended automatically.
+    """
+    print(message, flush=True)
+
+
+# --- Pre-flight checks -------------------------------------------------------
+
+
+def assert_root() -> None:
+    """Refuse to proceed unless the process is running as UID 0.
+
+    Raises:
+        PreflightError: When ``geteuid()`` is non-zero.
+    """
+    if os.geteuid() != 0:
+        raise PreflightError("minecraft-update.py must run as root (re-invoke with sudo)")
+
+
+# --- Lock-file handling ------------------------------------------------------
+
+
+def acquire_lock(lock_path: Path) -> "object":
+    """Acquire an exclusive non-blocking ``flock`` on ``lock_path``.
+
+    The lock is held for the lifetime of the returned file handle. Closing the handle releases the lock.
+
+    Args:
+        lock_path: Path to the lock file. Created if absent.
+
+    Returns:
+        The open file handle holding the lock. Caller closes when done.
+
+    Raises:
+        LockAcquisitionError: When the lock is already held by another process.
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(lock_path, "w", encoding="utf-8")  # noqa: SIM115 — caller manages lifetime.
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as exc:
+        handle.close()
+        raise LockAcquisitionError(f"another updater run holds {lock_path}: {exc}") from exc
+    handle.write(f"{os.getpid()}\n")
+    handle.flush()
+    return handle
+
+
+# --- Version-comparison helpers (used for log lines + Paper clamp) ----------
+
+
+def parse_semver_prefix(version_string: str) -> tuple[int, ...] | None:
+    """Extract the leading dotted-integer (semver-ish) prefix from a version string.
+
+    Handles real plugin.yml shapes:
+
+    - ``"2.10.0-SNAPSHOT"`` → ``(2, 10, 0)``
+    - ``"2.2.5-SNAPSHOT (b132-5a72b6a)"`` → ``(2, 2, 5)``
+    - ``"5.9.1"`` → ``(5, 9, 1)``
+
+    And API artifact-version shapes:
+
+    - ``"2.10.0-1143"`` → ``(2, 10, 0)``
+    - ``"1.21.8-60"`` → ``(1, 21, 8)``
+
+    Args:
+        version_string: Raw version string.
+
+    Returns:
+        Tuple of integer components, or ``None`` when no leading semver-ish prefix is present.
+    """
+    match = _SEMVER_PREFIX_RE.match(version_string)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.group(1).split("."))
+
+
+def parse_floodgate_build_suffix(version_string: str) -> int | None:
+    """Extract the build number from Floodgate's ``(b<N>-<sha>)`` plugin.yml suffix.
+
+    Floodgate's plugin.yml carries a trailing parenthesized build descriptor like
+    ``"2.2.5-SNAPSHOT (b132-5a72b6a)"``. Geyser and ViaVersion do not.
+
+    Args:
+        version_string: Raw version string from ``read_plugin_version``.
+
+    Returns:
+        The integer build number when the ``(b<N>-`` pattern is present, otherwise ``None``.
+    """
+    match = _FLOODGATE_BUILD_RE.search(version_string)
+    return int(match.group(1)) if match else None
+
+
+def parse_trailing_dash_int(version_string: str) -> int | None:
+    """Extract the trailing ``-<int>`` from an API artifact version string.
+
+    API ``artifact.version`` values for Geyser/Floodgate/Paper end in ``-<build>`` (e.g. ``"2.10.0-1143"``).
+    ViaVersion does not (its version is a plain Hangar name like ``"5.9.1"``).
+
+    Args:
+        version_string: API artifact version string.
+
+    Returns:
+        The trailing integer, or ``None`` when no ``-<digits>`` suffix is present.
+    """
+    match = _TRAILING_DASH_INT_RE.search(version_string)
+    return int(match.group(1)) if match else None
+
+
+def is_paper_build_newer(installed_build: int, api_build: int) -> bool:
+    """Paper integer-build comparison.
+
+    Args:
+        installed_build: The currently-running Paper build.
+        api_build: The API's latest Paper build for the same MC version.
+
+    Returns:
+        True iff ``api_build > installed_build``.
+    """
+    return api_build > installed_build
+
+
+def assert_paper_same_mc(
+    installed_mc: str, api_mc: str, *, max_build: int | None = None, api_build: int | None = None
+) -> None:
+    """Refuse to apply a Paper update that crosses MC versions or exceeds ``max_build``.
+
+    Args:
+        installed_mc: MC version currently recorded in ``version_history.json``.
+        api_mc: MC version the API's latest Paper build belongs to.
+        max_build: Optional ``--max-paper-build`` clamp.
+        api_build: The API's latest Paper build (required when ``max_build`` is set).
+
+    Raises:
+        PaperMcVersionMismatchError: When the MC versions differ or when ``api_build`` exceeds ``max_build``.
+    """
+    if installed_mc != api_mc:
+        raise PaperMcVersionMismatchError(
+            f"refusing Paper cross-MC bump: installed MC {installed_mc} vs API latest MC {api_mc}. "
+            f"Run install.py with --mc-version to move MC versions explicitly."
+        )
+    if max_build is not None and api_build is not None and api_build > max_build:
+        raise PaperMcVersionMismatchError(f"refusing Paper build {api_build}: exceeds --max-paper-build {max_build}")
+
+
+def is_semver_update_available(installed_version: str, api_version: str) -> bool:
+    """Compare semver prefixes; for equal prefixes, compare trailing build numbers when both are known.
+
+    Used to decide direction (``"X → Y"`` log line) and to flag the rare case where the API's reported
+    "latest" is somehow strictly older than what is installed (treated as no-op).
+
+    Args:
+        installed_version: Plugin's installed version string (from plugin.yml).
+        api_version: API artifact version string.
+
+    Returns:
+        True when the API's version is strictly newer than installed (semver or trailing build), False
+        when equal-or-older or when comparison is indeterminate.
+    """
+    installed_semver = parse_semver_prefix(installed_version)
+    api_semver = parse_semver_prefix(api_version)
+    if installed_semver is None or api_semver is None:
+        return False
+    if api_semver != installed_semver:
+        return api_semver > installed_semver
+    api_build = parse_trailing_dash_int(api_version)
+    installed_build = parse_floodgate_build_suffix(installed_version)
+    if api_build is not None and installed_build is not None:
+        return api_build > installed_build
+    return False
+
+
+# --- API + on-disk reconciliation -------------------------------------------
+
+
+def fetch_artifact_for(component: str, cli_overrides: dict[str, object]) -> JarArtifact:
+    """Fetch the API's latest artifact metadata for ``component``, honoring optional pin overrides.
+
+    Args:
+        component: Component identifier.
+        cli_overrides: A dict of overrides keyed by CLI flag name (e.g.
+            ``{"paper_mc_version": "1.21.8", "geyser_version": None, ...}``).
+
+    Returns:
+        A populated ``JarArtifact``.
+
+    Raises:
+        DownloadError: When the API call fails.
+        ValueError: When ``component`` is unrecognized.
+    """
+    if component == COMPONENT_PAPER:
+        mc_version = cli_overrides.get("paper_mc_version")
+        if not isinstance(mc_version, str):
+            raise ValueError("fetch_artifact_for(paper) requires paper_mc_version in cli_overrides")
+        return fetch_paper_artifact(mc_version, "latest")
+    if component == COMPONENT_GEYSER:
+        return fetch_geyser_like_artifact(COMPONENT_GEYSER, GEYSER_API_BASE, version=None, build=None)
+    if component == COMPONENT_FLOODGATE:
+        return fetch_geyser_like_artifact(COMPONENT_FLOODGATE, FLOODGATE_API_BASE, version=None, build=None)
+    if component == COMPONENT_VIAVERSION:
+        return fetch_viaversion_artifact(None)
+    raise ValueError(f"unknown component {component!r}")
+
+
+def installed_version_for(component: str, paths: UpdatePaths) -> str | None:
+    """Read the installed version string for ``component`` from disk.
+
+    Args:
+        component: Component identifier.
+        paths: Resolved on-disk paths.
+
+    Returns:
+        A human-readable version string (e.g. ``"1.21.8-58"`` for Paper, ``"2.10.0-SNAPSHOT"`` for plugins),
+        or ``None`` when the source is missing / unreadable.
+    """
+    if component == COMPONENT_PAPER:
+        history = read_mc_version_from_history(paths.server_dir)
+        if history is None:
+            return None
+        mc, build = history
+        return f"{mc}-{build}"
+    jar = paths.jar_for(component)
+    if not jar.exists():
+        return None
+    return read_plugin_version(jar)
+
+
+# --- Planning ----------------------------------------------------------------
+
+
+def build_plan(
+    components: Sequence[str],
+    paths: UpdatePaths,
+    cli_overrides: dict[str, object],
+    *,
+    force: bool,
+) -> list[ComponentPlan]:
+    """Return one ``ComponentPlan`` per requested component.
+
+    For each component, this resolves the API's latest artifact, hashes the installed jar (if any), and
+    decides whether the update applies. For Paper specifically, the MC-version clamp is enforced here so
+    a cross-MC API ``latest`` halts the run before any swap.
+
+    Args:
+        components: Components to plan for. Subset of ``ALL_COMPONENTS``.
+        paths: Resolved on-disk paths.
+        cli_overrides: CLI flag overrides (see ``fetch_artifact_for``).
+        force: When true, every component plans an ``"apply"`` even if sha256 matches.
+
+    Returns:
+        A list of plans in the order ``components`` was given.
+
+    Raises:
+        PaperMcVersionMismatchError: When the API's latest Paper crosses MC versions or exceeds
+            ``--max-paper-build``.
+        DownloadError: From the API fetch.
+    """
+    plans: list[ComponentPlan] = []
+    for component in components:
+        installed_version = installed_version_for(component, paths)
+        jar = paths.jar_for(component)
+        installed_sha = sha256_of_file(jar) if jar.exists() else None
+
+        if component == COMPONENT_PAPER:
+            history = read_mc_version_from_history(paths.server_dir)
+            if history is None:
+                log(f"[skip] paper: no version_history.json yet (server hasn't booted) — try again tomorrow")
+                continue
+            installed_mc, _installed_build = history
+            cli_overrides_with_mc = {**cli_overrides, "paper_mc_version": installed_mc}
+            artifact = fetch_artifact_for(component, cli_overrides_with_mc)
+            api_build = parse_trailing_dash_int(artifact.version)
+            assert_paper_same_mc(
+                installed_mc=installed_mc,
+                api_mc=installed_mc,
+                max_build=(
+                    cli_overrides.get("max_paper_build")
+                    if isinstance(cli_overrides.get("max_paper_build"), int)
+                    else None
+                ),
+                api_build=api_build,
+            )
+        else:
+            artifact = fetch_artifact_for(component, cli_overrides)
+
+        if not jar.exists():
+            action = "missing"
+        elif force or installed_sha != artifact.sha256:
+            action = "apply"
+        else:
+            action = "skip"
+
+        plans.append(
+            ComponentPlan(
+                component=component,
+                installed_version=installed_version,
+                installed_sha256=installed_sha,
+                artifact=artifact,
+                action=action,
+            )
+        )
+    return plans
+
+
+# --- Atomic swap + backup ----------------------------------------------------
+
+
+def staging_path_for(jar: Path) -> Path:
+    """Return the staging path used for a fresh download before the atomic swap.
+
+    Args:
+        jar: Final destination jar.
+
+    Returns:
+        ``<jar>.new`` in the same directory.
+    """
+    return jar.with_suffix(jar.suffix + ".new")
+
+
+def timestamped_backup_path(jar: Path, *, now: datetime | None = None) -> Path:
+    """Return the timestamped backup path for ``jar``.
+
+    Args:
+        jar: Jar being backed up.
+        now: Override the timestamp (for tests). Defaults to current UTC time.
+
+    Returns:
+        ``<jar>.<UTC timestamp>``.
+    """
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    return jar.with_suffix(jar.suffix + "." + now.strftime(BACKUP_TIMESTAMP_FORMAT))
+
+
+def list_backups(jar: Path) -> list[Path]:
+    """List timestamped backups of ``jar`` in chronological order.
+
+    Args:
+        jar: Jar whose siblings to scan.
+
+    Returns:
+        List of backup paths sorted oldest-first.
+    """
+    if not jar.parent.is_dir():
+        return []
+    prefix = jar.name + "."
+    matches: list[Path] = []
+    for sibling in jar.parent.iterdir():
+        if not sibling.name.startswith(prefix):
+            continue
+        suffix = sibling.name[len(prefix) :]
+        if _BACKUP_TIMESTAMP_RE.fullmatch("." + suffix):
+            matches.append(sibling)
+    matches.sort(key=lambda p: p.name)
+    return matches
+
+
+def prune_backups(jar: Path, retention: int) -> list[Path]:
+    """Delete the oldest backups beyond ``retention``.
+
+    Args:
+        jar: Jar whose backups to prune.
+        retention: How many most-recent backups to keep.
+
+    Returns:
+        The list of removed backup paths.
+    """
+    backups = list_backups(jar)
+    excess = backups[: max(0, len(backups) - retention)]
+    for old in excess:
+        log(f"[prune] backup {old.name}")
+        old.unlink()
+    return excess
+
+
+def download_to_staging(artifact: JarArtifact, dest_jar: Path) -> Path:
+    """Download ``artifact`` to the staging path and sha256-verify before returning.
+
+    Args:
+        artifact: API metadata.
+        dest_jar: Final jar path (the staging path is derived from it).
+
+    Returns:
+        The staging path holding verified bytes.
+
+    Raises:
+        ChecksumMismatchError: When the downloaded bytes do not match ``artifact.sha256``. The staging
+            file is removed.
+        DownloadError: When the HTTP fetch fails.
+    """
+    staging = staging_path_for(dest_jar)
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    if staging.exists():
+        staging.unlink()
+    log(f"[download] {artifact.label} {artifact.version} → {staging.name}")
+    http_download_to_file(artifact.download_url, staging)
+    observed = sha256_of_file(staging)
+    if observed != artifact.sha256:
+        staging.unlink()
+        raise ChecksumMismatchError(
+            f"{artifact.label} {artifact.version}: expected sha256 {artifact.sha256}, got {observed}"
+        )
+    return staging
+
+
+def atomic_swap(jar: Path, staging: Path, *, owner_user: str, owner_group: str, now: datetime | None = None) -> Path:
+    """Atomically swap ``jar`` for ``staging``, leaving a timestamped backup of the previous jar.
+
+    Pre-condition: ``jar`` exists and ``staging`` exists. The directory entry for ``jar`` is renamed to
+    a timestamped backup, then ``staging`` is renamed into place. Ownership is applied to the new file.
+
+    Args:
+        jar: Final jar path.
+        staging: Verified replacement contents.
+        owner_user: Owning user (chown applied to swapped-in jar).
+        owner_group: Owning group.
+        now: Timestamp override (for tests).
+
+    Returns:
+        The backup path the old jar was moved to.
+    """
+    backup = timestamped_backup_path(jar, now=now)
+    log(f"[swap] {jar.name} → {backup.name}; {staging.name} → {jar.name}")
+    jar.rename(backup)
+    staging.rename(jar)
+    _chown(jar, owner_user, owner_group)
+    return backup
+
+
+def rollback_swap(jar: Path, backup: Path) -> None:
+    """Undo an ``atomic_swap`` by moving ``backup`` back into ``jar``'s position.
+
+    If ``jar`` is present, it is moved aside to ``<jar>.failed.<timestamp>`` so the operator can inspect
+    why the rollback was needed.
+
+    Args:
+        jar: The jar that was swapped in (now considered failed).
+        backup: The pre-swap backup path.
+    """
+    if jar.exists():
+        failed = jar.with_suffix(
+            jar.suffix + ".failed." + datetime.now(tz=timezone.utc).strftime(BACKUP_TIMESTAMP_FORMAT)
+        )
+        log(f"[rollback] {jar.name} → {failed.name} (suspect)")
+        jar.rename(failed)
+    log(f"[rollback] {backup.name} → {jar.name}")
+    backup.rename(jar)
+
+
+def _chown(path: Path, owner_user: str, owner_group: str) -> None:
+    """Run ``chown <owner_user>:<owner_group> <path>`` via subprocess.
+
+    Args:
+        path: Target path.
+        owner_user: Owning user.
+        owner_group: Owning group.
+    """
+    subprocess.run(  # noqa: S603 — argv as list, no shell.
+        ["chown", f"{owner_user}:{owner_group}", str(path)],
+        check=True,
+    )
+
+
+# --- Service lifecycle -------------------------------------------------------
+
+
+def systemctl_restart(unit: str, *, dry_run: bool = False) -> None:
+    """Restart a systemd unit.
+
+    Args:
+        unit: Unit name.
+        dry_run: When true, log without running.
+    """
+    _run(["systemctl", "restart", unit], dry_run=dry_run)
+
+
+def systemctl_is_active(unit: str) -> bool:
+    """Return whether ``systemctl is-active --quiet <unit>`` reports active.
+
+    Args:
+        unit: Unit name.
+
+    Returns:
+        True when ``systemctl is-active`` exits 0.
+    """
+    proc = subprocess.run(  # noqa: S603 — argv as list, no shell.
+        ["systemctl", "is-active", "--quiet", unit],
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def wait_for_active(unit: str, timeout_s: int = RESTART_WAIT_TIMEOUT_S, poll_s: int = RESTART_POLL_INTERVAL_S) -> bool:
+    """Poll ``systemctl is-active`` until the unit is active or the timeout elapses.
+
+    Args:
+        unit: Unit name.
+        timeout_s: Maximum seconds to wait.
+        poll_s: Seconds between polls.
+
+    Returns:
+        True when the unit became active inside the window, False on timeout.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if systemctl_is_active(unit):
+            return True
+        time.sleep(poll_s)
+    return systemctl_is_active(unit)
+
+
+def tcp_probe(host: str = TCP_PROBE_HOST, port: int = TCP_PROBE_PORT, timeout_s: float = TCP_PROBE_TIMEOUT_S) -> bool:
+    """Attempt a single TCP connect to ``(host, port)``; return whether the connect succeeded.
+
+    UDP 19132 (Bedrock) is intentionally not probed — UDP is connectionless and a probe would only verify
+    that the kernel accepts the socket, not that Geyser is actually serving. The TCP 25565 probe + the
+    ``systemctl is-active`` check are sufficient as a smoke test.
+
+    Args:
+        host: Target host (default loopback).
+        port: Target port (default Java 25565).
+        timeout_s: Connect timeout.
+
+    Returns:
+        True on a successful connect, False on any socket error.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return True
+    except OSError:
+        return False
+
+
+def wait_for_tcp(
+    host: str = TCP_PROBE_HOST,
+    port: int = TCP_PROBE_PORT,
+    total_window_s: int = TCP_PROBE_TOTAL_WINDOW_S,
+    poll_interval_s: int = TCP_PROBE_POLL_INTERVAL_S,
+    per_attempt_timeout_s: float = TCP_PROBE_TIMEOUT_S,
+) -> bool:
+    """Poll ``tcp_probe`` until it succeeds or ``total_window_s`` elapses.
+
+    Paper's cold restart leaves the JVM "active" per systemd well before 25565 is bound — empirically
+    20–60s of world load + plugin enable happens after ``is-active`` flips. A one-shot probe right after
+    is-active is too aggressive and causes false-positive rollbacks. Polling absorbs the variance.
+
+    Args:
+        host: Target host.
+        port: Target port.
+        total_window_s: Max seconds to keep polling before giving up.
+        poll_interval_s: Delay between attempts.
+        per_attempt_timeout_s: Per-attempt connect timeout (passed through to ``tcp_probe``).
+
+    Returns:
+        True when the port opens inside the window, False on timeout.
+    """
+    deadline = time.monotonic() + total_window_s
+    while True:
+        if tcp_probe(host, port, timeout_s=per_attempt_timeout_s):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(poll_interval_s)
+
+
+def restart_and_verify(unit: str = MINECRAFT_SERVICE_NAME, *, skip_probe: bool = False, dry_run: bool = False) -> None:
+    """Restart ``unit`` and verify it comes back up via systemd + TCP probe.
+
+    Args:
+        unit: Service unit name.
+        skip_probe: When true, skip the TCP probe (still wait for is-active).
+        dry_run: When true, log the planned restart without running it.
+
+    Raises:
+        ServiceRestartError: When the unit fails to become active inside ``RESTART_WAIT_TIMEOUT_S``, or
+            when the TCP probe never succeeds inside ``TCP_PROBE_TOTAL_WINDOW_S``.
+    """
+    systemctl_restart(unit, dry_run=dry_run)
+    if dry_run:
+        return
+    if not wait_for_active(unit):
+        raise ServiceRestartError(f"{unit} did not become active within {RESTART_WAIT_TIMEOUT_S}s")
+    log(f"[ok] {unit} is active")
+    if skip_probe:
+        return
+    time.sleep(TCP_PROBE_GRACE_S)
+    log(f"[probe] polling TCP {TCP_PROBE_HOST}:{TCP_PROBE_PORT} for up to {TCP_PROBE_TOTAL_WINDOW_S}s")
+    if not wait_for_tcp():
+        raise ServiceRestartError(
+            f"{unit} reports active but TCP {TCP_PROBE_HOST}:{TCP_PROBE_PORT} did not open within "
+            f"{TCP_PROBE_TOTAL_WINDOW_S}s"
+        )
+    log(f"[ok] tcp probe {TCP_PROBE_HOST}:{TCP_PROBE_PORT} succeeded")
+
+
+# --- Floodgate key invariant -------------------------------------------------
+
+
+def assert_floodgate_key_untouched(paths: UpdatePaths, sha_before: str | None) -> None:
+    """Assert ``plugins/floodgate/key.pem`` was not modified during the run.
+
+    The updater never reads, writes, or touches the key. This assertion is paranoia — it catches
+    accidental sibling-glob bugs that would otherwise destroy Bedrock auth silently.
+
+    Args:
+        paths: Resolved on-disk paths.
+        sha_before: The key's sha256 captured at the start of the run, or ``None`` when no key existed.
+
+    Raises:
+        UpdateError: When the key's hash changed (or it gained/lost existence).
+    """
+    sha_after = sha256_of_file(paths.floodgate_key) if paths.floodgate_key.exists() else None
+    if sha_before != sha_after:
+        raise UpdateError(
+            f"INVARIANT VIOLATED: floodgate {paths.floodgate_key} hash changed "
+            f"({sha_before} → {sha_after}) during the updater run. Manual recovery required — the key "
+            f"must NEVER be touched by the updater."
+        )
+
+
+# --- Apply phase -------------------------------------------------------------
+
+
+def apply_plans(
+    plans: Sequence[ComponentPlan],
+    paths: UpdatePaths,
+    *,
+    owner_user: str,
+    owner_group: str,
+    no_restart: bool,
+    skip_probe: bool,
+    retention: int,
+    dry_run: bool,
+    now: datetime | None = None,
+) -> int:
+    """Execute the plans: download, swap, restart, verify, prune. Roll back on failure.
+
+    Args:
+        plans: Output of ``build_plan``.
+        paths: Resolved on-disk paths.
+        owner_user: Service-account user (applied to swapped-in jars).
+        owner_group: Service-account group.
+        no_restart: When true, skip the post-swap service restart entirely.
+        skip_probe: When true, skip the TCP probe after restart.
+        retention: Backup retention (per component).
+        dry_run: When true, log the plan without performing it.
+        now: Timestamp override (for tests).
+
+    Returns:
+        Number of components that actually updated.
+
+    Raises:
+        ChecksumMismatchError: Surfaced from download verification.
+        ServiceRestartError: When the post-restart smoke check fails (after rollback).
+        DownloadError: From the API/jar fetch.
+    """
+    for plan in plans:
+        descriptor = plan.installed_version or "(none)"
+        if plan.action == "skip":
+            log(f"[skip] {plan.component} {descriptor} up-to-date (sha {plan.artifact.sha256[:12]}…)")
+        elif plan.action == "missing":
+            log(f"[skip] {plan.component} jar missing on disk — run install.py to place it; skipping")
+        else:
+            log(
+                f"[plan] {plan.component} {descriptor} → {plan.artifact.version} "
+                f"(sha {(plan.installed_sha256 or 'none')[:12]}… → {plan.artifact.sha256[:12]}…)"
+            )
+
+    to_apply = [p for p in plans if p.action == "apply"]
+    if not to_apply:
+        log("[ok] nothing to update")
+        return 0
+
+    if dry_run:
+        log(f"[dry-run] would update {len(to_apply)} component(s); skipping download/swap/restart")
+        return 0
+
+    floodgate_key_sha = sha256_of_file(paths.floodgate_key) if paths.floodgate_key.exists() else None
+
+    staged: list[tuple[ComponentPlan, Path]] = []
+    swapped: list[tuple[ComponentPlan, Path, Path]] = []  # (plan, jar, backup)
+
+    try:
+        for plan in to_apply:
+            jar = paths.jar_for(plan.component)
+            staging = download_to_staging(plan.artifact, jar)
+            staged.append((plan, staging))
+
+        for plan, staging in staged:
+            jar = paths.jar_for(plan.component)
+            backup = atomic_swap(jar, staging, owner_user=owner_user, owner_group=owner_group, now=now)
+            swapped.append((plan, jar, backup))
+
+        if not no_restart:
+            try:
+                restart_and_verify(skip_probe=skip_probe, dry_run=False)
+            except ServiceRestartError:
+                _rollback_all(swapped)
+                # Best-effort restart on the restored jars so the server is up regardless.
+                try:
+                    restart_and_verify(skip_probe=True, dry_run=False)
+                except ServiceRestartError as exc2:
+                    log(f"[error] post-rollback restart also failed: {exc2}")
+                raise
+
+        for plan, jar, _backup in swapped:
+            prune_backups(jar, retention)
+        for plan in to_apply:
+            jar = paths.jar_for(plan.component)
+            log(f"[done] {plan.component} {plan.installed_version or '(none)'} → {plan.artifact.version}")
+    finally:
+        for _plan, staging in staged:
+            if staging.exists():
+                # If a staging file is still around at this point, the swap never happened — clean it up.
+                staging.unlink()
+
+    assert_floodgate_key_untouched(paths, floodgate_key_sha)
+    return len(swapped)
+
+
+def _rollback_all(swapped: Sequence[tuple[ComponentPlan, Path, Path]]) -> None:
+    """Roll back every swap in reverse order.
+
+    Args:
+        swapped: List of ``(plan, jar, backup)`` tuples from a successful swap phase.
+    """
+    for plan, jar, backup in reversed(list(swapped)):
+        log(f"[rollback] {plan.component} {plan.artifact.version} → {plan.installed_version or '(none)'}")
+        rollback_swap(jar, backup)
+
+
+# --- Systemd unit install (--install-systemd-units) -------------------------
+
+
+def render_updater_service(script_path: Path = UPDATER_SCRIPT_INSTALL_PATH) -> str:
+    """Render the ``minecraft-update.service`` unit content.
+
+    Args:
+        script_path: Path to the installed updater script.
+
+    Returns:
+        Rendered unit content.
+    """
+    return UPDATER_SERVICE_TEMPLATE.format(script_path=script_path)
+
+
+def render_updater_timer(
+    oncalendar: str = DEFAULT_TIMER_ONCALENDAR, randomized_delay: str = DEFAULT_TIMER_RANDOMIZED_DELAY
+) -> str:
+    """Render the ``minecraft-update.timer`` unit content.
+
+    Args:
+        oncalendar: ``OnCalendar=`` expression.
+        randomized_delay: ``RandomizedDelaySec=`` value.
+
+    Returns:
+        Rendered timer content.
+    """
+    return UPDATER_TIMER_TEMPLATE.format(oncalendar=oncalendar, randomized_delay=randomized_delay)
+
+
+def write_unit_if_changed(path: Path, content: str, *, dry_run: bool = False) -> bool:
+    """Write ``content`` to ``path`` only if the existing file differs.
+
+    Args:
+        path: Target unit path.
+        content: Desired content.
+        dry_run: When true, log without writing.
+
+    Returns:
+        True when the file was written (or would be in dry-run), False when content matched.
+    """
+    desired = content.encode("utf-8")
+    if path.exists() and path.read_bytes() == desired:
+        log(f"[skip] {path} already matches desired content")
+        return False
+    if dry_run:
+        log(f"[dry-run] write {len(desired)} bytes to {path}")
+        return True
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(desired)
+    path.chmod(0o644)
+    log(f"[write] {path}")
+    return True
+
+
+def install_systemd_units(
+    *,
+    oncalendar: str = DEFAULT_TIMER_ONCALENDAR,
+    randomized_delay: str = DEFAULT_TIMER_RANDOMIZED_DELAY,
+    script_path: Path = UPDATER_SCRIPT_INSTALL_PATH,
+    service_path: Path = UPDATER_SERVICE_PATH,
+    timer_path: Path = UPDATER_TIMER_PATH,
+    dry_run: bool = False,
+) -> int:
+    """Install / refresh ``minecraft-update.{service,timer}`` and enable the timer.
+
+    Idempotent: rewrites unit files only when content differs, runs ``daemon-reload`` only when any unit
+    actually changed, and runs ``systemctl enable --now`` on the timer (a no-op when already enabled-and-
+    running per systemd semantics). Re-running against an already-configured host produces zero side
+    effects: no rewritten files, no daemon-reload, no service flap.
+
+    Args:
+        oncalendar: Timer ``OnCalendar=`` expression.
+        randomized_delay: Timer ``RandomizedDelaySec=`` value.
+        script_path: Installed updater script path (referenced from the service unit's ExecStart).
+        service_path: Where to install the .service unit.
+        timer_path: Where to install the .timer unit.
+        dry_run: When true, log without writing or invoking systemd.
+
+    Returns:
+        Process exit code. ``0`` on success.
+    """
+    service_changed = write_unit_if_changed(service_path, render_updater_service(script_path), dry_run=dry_run)
+    timer_changed = write_unit_if_changed(
+        timer_path, render_updater_timer(oncalendar, randomized_delay), dry_run=dry_run
+    )
+    if service_changed or timer_changed:
+        _run(["systemctl", "daemon-reload"], dry_run=dry_run)
+    else:
+        log("[skip] daemon-reload (no unit changes)")
+    _run(["systemctl", "enable", "--now", UPDATER_TIMER_NAME], dry_run=dry_run)
+    return 0
+
+
+def _run(argv: Sequence[str], *, dry_run: bool = False) -> None:
+    """Run a local command, honoring ``--dry-run``.
+
+    Args:
+        argv: Command tokens.
+        dry_run: When true, log only.
+    """
+    rendered = " ".join(shlex.quote(t) for t in argv)
+    if dry_run:
+        log(f"[dry-run] {rendered}")
+        return
+    log(f"[run] {rendered}")
+    subprocess.run(list(argv), check=True)  # noqa: S603 — argv as list, no shell.
+
+
+# --- Main --------------------------------------------------------------------
+
+
+def update(args: argparse.Namespace) -> int:
+    """Run the full updater pipeline once.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Process exit code.
+    """
+    if args.install_systemd_units:
+        return install_systemd_units(
+            oncalendar=args.timer_oncalendar,
+            randomized_delay=args.timer_randomized_delay,
+            dry_run=args.dry_run,
+        )
+
+    assert_root()
+
+    try:
+        lock_handle = acquire_lock(args.lock_file)
+    except LockAcquisitionError as exc:
+        log(f"[skip] {exc}")
+        return 0
+
+    try:
+        paths = UpdatePaths.from_data_root(args.data_root)
+        components = list(args.components) if args.components else list(ALL_COMPONENTS)
+
+        cli_overrides: dict[str, object] = {
+            "max_paper_build": args.max_paper_build,
+        }
+        plans = build_plan(components, paths, cli_overrides, force=args.force)
+        # apply_plans returns the count of swapped components for callers/tests; the process exit code
+        # is 0 on any non-raising completion (zero updates, dry-run, or N successful swaps all map to 0).
+        apply_plans(
+            plans,
+            paths,
+            owner_user=args.minecraft_user,
+            owner_group=args.minecraft_group,
+            no_restart=args.no_restart,
+            skip_probe=args.skip_probe,
+            retention=args.keep_backups,
+            dry_run=args.dry_run,
+        )
+        return 0
+    finally:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_handle.close()
+
+
+def _parse_components_csv(value: str) -> list[str]:
+    """Parse a ``--components`` CSV list and validate each entry.
+
+    Args:
+        value: Raw CLI string (e.g. ``"geyser,floodgate"``).
+
+    Returns:
+        Validated component identifiers in input order.
+
+    Raises:
+        argparse.ArgumentTypeError: When an entry is not a known component.
+    """
+    parts = [p.strip() for p in value.split(",") if p.strip()]
+    unknown = [p for p in parts if p not in ALL_COMPONENTS]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            f"unknown component(s): {', '.join(unknown)}. Valid: {', '.join(ALL_COMPONENTS)}"
+        )
+    return parts
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    """Build the CLI parser.
+
+    Returns:
+        The configured parser.
+    """
+    parser = argparse.ArgumentParser(
+        prog="minecraft-update.py",
+        description=(
+            "Idempotent nightly updater for Paper + Geyser + Floodgate + ViaVersion. Designed to run as "
+            "root under the minecraft-update.timer systemd timer. Connectivity preservation for Bedrock "
+            "clients is the primary motivation: see the module docstring."
+        ),
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=DEFAULT_DATA_ROOT,
+        help=f"Mountpoint of the data volume (default: {DEFAULT_DATA_ROOT}).",
+    )
+    parser.add_argument(
+        "--components",
+        type=_parse_components_csv,
+        default=None,
+        help=("Comma-separated subset of components to consider " f"(default: all of {','.join(ALL_COMPONENTS)})."),
+    )
+    parser.add_argument(
+        "--minecraft-user",
+        default=DEFAULT_USER,
+        help=f"Service user (default: {DEFAULT_USER}).",
+    )
+    parser.add_argument(
+        "--minecraft-group",
+        default=DEFAULT_GROUP,
+        help=f"Service group (default: {DEFAULT_GROUP}).",
+    )
+    parser.add_argument(
+        "--max-paper-build",
+        type=int,
+        default=None,
+        help="Refuse to apply Paper builds higher than this within the current MC version.",
+    )
+    parser.add_argument(
+        "--keep-backups",
+        type=int,
+        default=DEFAULT_BACKUP_RETENTION,
+        help=f"Backups to retain per component (default: {DEFAULT_BACKUP_RETENTION}).",
+    )
+    parser.add_argument(
+        "--lock-file",
+        dest="lock_file",
+        type=Path,
+        default=DEFAULT_LOCK_PATH,
+        help=f"Override the lock-file path (default: {DEFAULT_LOCK_PATH}).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download and swap even when sha256 matches (sha256-corruption recovery).",
+    )
+    parser.add_argument(
+        "--no-restart",
+        action="store_true",
+        help="Apply jar updates but skip the systemctl restart (operator orchestrates downtime).",
+    )
+    parser.add_argument(
+        "--skip-probe",
+        action="store_true",
+        help="Skip the post-restart TCP 25565 probe (still wait for systemctl is-active).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print every mutation that would be performed without executing it.",
+    )
+    parser.add_argument(
+        "--install-systemd-units",
+        action="store_true",
+        help=(
+            "Install /etc/systemd/system/minecraft-update.{service,timer} (idempotently) and enable the "
+            "timer. Skips the update flow entirely."
+        ),
+    )
+    parser.add_argument(
+        "--timer-oncalendar",
+        default=DEFAULT_TIMER_ONCALENDAR,
+        help=f"Timer OnCalendar= expression for --install-systemd-units (default: '{DEFAULT_TIMER_ONCALENDAR}').",
+    )
+    parser.add_argument(
+        "--timer-randomized-delay",
+        default=DEFAULT_TIMER_RANDOMIZED_DELAY,
+        help=(
+            "Timer RandomizedDelaySec= value for --install-systemd-units "
+            f"(default: {DEFAULT_TIMER_RANDOMIZED_DELAY})."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point.
+
+    Args:
+        argv: Optional CLI arg list (``None`` reads from ``sys.argv``).
+
+    Returns:
+        Process exit code. ``0`` on success, ``2`` on pre-flight / clamp failure, ``3`` on
+        download/checksum failure, ``4`` on service-restart failure, ``1`` on any other update error.
+    """
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+    try:
+        return update(args)
+    except PreflightError as exc:
+        print(f"pre-flight check failed: {exc}", file=sys.stderr)
+        return 2
+    except PaperMcVersionMismatchError as exc:
+        print(f"paper clamp refused update: {exc}", file=sys.stderr)
+        return 2
+    except (DownloadError, ChecksumMismatchError) as exc:
+        print(f"download failed: {exc}", file=sys.stderr)
+        return 3
+    except ServiceRestartError as exc:
+        print(f"service restart failed: {exc}", file=sys.stderr)
+        return 4
+    except UpdateError as exc:
+        print(f"update failed: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- New `scripts/server/update.py` — stdlib-only idempotent updater. sha256-driven decision (only swaps when the on-disk
  jar's hash differs from the API's reported hash), atomic swap with timestamped backups, rollback + service restart on
  any failure mid-update. Paper is clamped to the running MC version's build stream (refuses cross-MC bumps regardless
  of what the API reports as `latest`). `plugins/floodgate/key.pem` is asserted-untouched at the end of every run.
  Concurrent runs mutually excluded via `fcntl.flock` on `/run/minecraft-update.lock`.
- Systemd integration via `minecraft-update.timer` (daily `OnCalendar=*-*-* 10:00:00 UTC` with
  `RandomizedDelaySec=3600`, `Persistent=true`) + `minecraft-update.service` (oneshot, `User=root`). The unit-file
  content lives only in `update.py` — `update.py --install-systemd-units` is the single self-install path, called by
  both `install.py` (fresh provisions) and the new `scripts/server/deploy-updater.sh` (operator-side script for the
  existing hand-built live host).
- Shared HTTP / sha256 / API-fetcher / version-reader primitives extracted to `scripts/server/_common.py` and imported
  by both `install.py` and `update.py` — keeps the diff small and gives the two scripts one source of truth for the
  PaperMC Fill v3, Geyser/Floodgate v2, and Hangar API shapes.

End-to-end validated against the live host before opening: `deploy-updater.sh` ran successfully, timer landed
idempotently, `systemctl start minecraft-update.service` exited 0, all three plugins moved to API-latest sha (Geyser
2.10.0-1143, Floodgate 2.2.5-132, ViaVersion 5.9.1), Floodgate key sha unchanged across three back-to-back runs,
`minecraft.service` stayed healthy. Three real-host bugs surfaced and were fixed during that validation: TCP probe
needed polling (Paper takes 25–60s to bind 25565 post-restart, not the 10s grace I had), the live host's Floodgate jar
is `Floodgate-Spigot.jar` (capital F) not the upstream-default `floodgate-spigot.jar`, and the exit code was leaking
the count of swapped components so systemd saw 3 = failure.

Closes #14

## Test plan

- [x] `pytest scripts/server/` → **122 passed, 9 skipped** (8 e2e + 1 macOS case-FS guard).
- [x] `black --check scripts/server/` clean.
- [x] `shellcheck scripts/server/deploy-updater.sh` clean.
- [x] `scripts/server/deploy-updater.sh` executed against the live LightSail host: rsync delivered `update.py` +
      `_common.py`, `install` renamed to `minecraft-update.py` with `root:root 0755`, `--install-systemd-units` dropped
      both unit files + enabled the timer. Re-running the deploy was a no-op (`already matches desired content`,
      `daemon-reload (no unit changes)`).
- [x] `systemctl list-timers minecraft-update.timer` shows next fire at the expected window (10:00 UTC + randomized
      delay, ~12h out).
- [x] `systemctl start minecraft-update.service` against the live host completed with `Result=success`,
      `ExecMainStatus=0`. Journal shows the sha-driven skip path firing for all four components (Paper deferred because
      `version_history.json` doesn't exist on this hand-built host; Geyser/Floodgate/ViaVersion all up-to-date after the
      prior run).
- [x] Floodgate key sha256 captured pre- and post-run across three runs (apply, rollback, no-op): **unchanged** at
      `7ba72afd…`.
- [x] `minecraft.service` `is-active` confirmed after every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
