### PR TITLE
docs: rewrite README to focus on what the repo does

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,112 +2,122 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project context
+## Commands
 
-The live deployment is on **AWS LightSail**. An earlier Azure backend (PR #2) was scrapped and the repo was reset
-on 2026-05-09 to reverse-engineer a hand-built LightSail Minecraft deployment into Terraform (issue #4, merged in
-PR #9). The repo was originally named `azure-hosted-minecraft` and renamed to `aws-hosted-minecraft` on 2026-05-09;
-historical commits, PR titles, and issue bodies may still mention Azure or the old name.
+### Python tests
 
-The eventual goal is idempotent scripts that can rebuild or repair the live server, plus a Python nightly updater
-for Paper / Geyser / Floodgate version bumps. The updater is deliberately not designed yet — it waits on issue #4
-(closed — Terraform import) and issue #5 (open — server-state capture from the live host), so its requirements
-are shaped by what those uncover.
+Run all unit tests from the repo root (pytest discovers `scripts/` via `pyproject.toml`):
+
+```bash
+pytest
+```
+
+Run a single test file or test:
+
+```bash
+pytest scripts/server/test_install.py
+pytest scripts/server/test_update.py::test_name
+```
+
+Run e2e tests that hit real external APIs (PaperMC Fill v3, Geyser/Floodgate v2, Hangar):
+
+```bash
+pytest --run-e2e
+```
+
+Format Python code (line length is 120, configured in `pyproject.toml`):
+
+```bash
+black scripts/server/
+```
+
+Lint shell scripts:
+
+```bash
+shellcheck scripts/server/deploy-updater.sh scripts/aws/verify-credentials.sh scripts/aws/inventory.sh
+```
+
+### Terraform
+
+Run from `infra/` (main layer) or `infra/bootstrap/` (bootstrap layer):
+
+```bash
+terraform fmt -recursive
+terraform validate
+terraform plan
+```
+
+`terraform apply` and `terraform destroy` are **operator-only** — never run them as an agent.
 
 ## Architecture
 
-The Terraform stack lives in two layers under `infra/`:
+### Two Terraform layers
 
-- **`infra/bootstrap/`** — provisions the S3 bucket + DynamoDB lock table that hold the main layer's remote state.
-  Has **no `backend` block**; its own state lives on the operator's laptop. This solves the chicken-and-egg of
-  bootstrapping its own state backend. Re-running this layer is rare (recovery scenarios only — see its README).
-- **`infra/`** — the main layer. Manages the live LightSail Minecraft deployment via an S3 backend whose values
-  come from `backend-configs/prod.hcl` (gitignored; the operator copies `prod.hcl.example` and fills in bucket /
-  lock-table / profile from the bootstrap layer's outputs).
+`infra/bootstrap/` creates the S3 bucket and DynamoDB table for remote state. It has no backend block (state lives on
+the operator's machine). `infra/` is the main layer; it uses the bootstrap layer's outputs as its S3 backend. Run
+bootstrap first on a fresh AWS account; subsequent infra work goes entirely in `infra/`.
 
-The main layer was authored by importing existing AWS resources, so `terraform plan` is zero changes for everything
-it manages. See `infra/README.md` for the full import map and the deliberately-not-imported resources:
-`aws_lightsail_instance_public_ports.mcserver` (provider gap — applied as a no-op to enter state), the
-`ssh-mcserver` key pair (the AWS provider docs explicitly forbid importing), LightSail snapshots (no provider
-resource exists), and the `bytehorizonforge.com` Route 53 zone — that one is a `data` source on purpose because it
-pre-existed this project and hosts unrelated Azure M365 records (`auth.bytehorizonforge.com`).
+### Three on-host Python scripts
 
-### File-per-concern Terraform layout
+All three scripts are stdlib-only (no pip-installable dependencies). They run as root on the LightSail host.
 
-No `main.tf` — ever. Resources are split by domain: `providers.tf`, `variables.tf`, `outputs.tf`, plus per-domain
-files (`lightsail.tf`, `networking.tf`, `storage.tf`, `dns.tf`). `infra/bootstrap/` follows the same pattern
-(`s3.tf`, `dynamodb.tf`). Modules under `infra/modules/<name>/` are acceptable only when a real reuse boundary
-appears — do not pre-extract speculatively. If a future PR proposes a `main.tf` or speculative module, push back.
+| Script                      | Role                                                                                                                                                                                                                                                 |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `scripts/server/_common.py` | Shared artifact fetchers (PaperMC Fill v3, Geyser/Floodgate v2, Hangar v1), HTTP helpers, sha256 utils, and on-disk version discovery. No side effects at import time.                                                                               |
+| `scripts/server/install.py` | One-time host provisioner. Installs Corretto JDK via apt, creates the `minecraft` user/group, downloads Paper + Geyser + Floodgate + ViaVersion, writes systemd units, and deploys the updater. Requires root and a mounted data volume.             |
+| `scripts/server/update.py`  | Nightly updater. Compares on-disk jar sha256 against the API's latest; downloads, atomically swaps, restarts the service, and rolls back on restart failure. Installed to `/usr/local/sbin/minecraft-update.py`; driven by `minecraft-update.timer`. |
 
-## Operator vs. agent split (Terraform)
+`install.py` and `update.py` import `_common.py` as a sibling module — both scripts must live in the same directory at
+runtime. `deploy-updater.sh` renames `update.py` → `minecraft-update.py` when deploying to the live host, then places
+`_common.py` beside it.
 
-The agent runs routine, low-risk Terraform commands. The operator runs anything that mutates AWS or initializes a
-layer for the first time. **The agent must stop at every operator-owned step**, even if the plan looks safe.
+### Data volume layout (`/srv/minecraft`)
 
-| Command                           | Owner    |
-|-----------------------------------|----------|
-| First `terraform init` per layer  | Operator |
-| Subsequent `terraform init`       | Agent    |
-| `terraform validate` / `fmt`      | Agent    |
-| `terraform plan`                  | Agent    |
-| `terraform import`                | Agent    |
-| `terraform state rm` / `state mv` | Agent    |
-| `terraform apply` / `destroy`     | Operator |
-
-## AWS authentication
-
-- Region `us-east-1`, profile `mc-aws` (IAM Identity Center, `AdministratorAccess` permission set). Pass
-  `--profile mc-aws` or set `AWS_PROFILE=mc-aws` for every `aws` / `terraform` invocation. The account ID lives
-  in operator-local config (`.env` / SSO cache); recover it on demand via `aws sts get-caller-identity` if you
-  need it.
-- The cached SSO token at `~/.aws/sso/cache/` typically expires every 8–12 hours. Recovery: `aws sso login
-  --profile mc-aws`.
-- `MC_AWS_PROFILE=mc-aws` lives in the gitignored `.env`. See `docs/aws-auth-setup.md` for the full IdC walkthrough
-  (Checkpoints A–F); `.env.example` lists every required key (also `MC_SSH_HOST`, `MC_SSH_USER`, `MC_SSH_KEY` for
-  reaching the live host).
-
-## Common commands
-
-```bash
-# Verify AWS CLI auth (read-only; run before anything that touches AWS).
-./scripts/aws/verify-credentials.sh
-
-# Snapshot every AWS resource the deployment depends on (drift detection).
-./scripts/aws/inventory.sh   # writes infra/aws-inventory.json (gitignored)
-
-# Bootstrap layer (rare — only on first setup or laptop recovery).
-cd infra/bootstrap && terraform fmt -recursive && terraform validate && terraform plan
-
-# Main layer.
-cd infra && terraform init -backend-config=backend-configs/prod.hcl
-terraform fmt -recursive && terraform validate && terraform plan   # plan must be zero changes
-
-# Lint shell scripts (project requires shellcheck-clean).
-shellcheck scripts/aws/*.sh
-
-# Python formatter (line-length 120 from pyproject.toml). Project requires Python 3.13+.
-black .
+```
+/srv/minecraft/
+└── server/
+    ├── paper.jar
+    ├── start.sh
+    ├── eula.txt
+    ├── version_history.json     # Paper writes this on first start; both scripts read it for MC version
+    └── plugins/
+        ├── Geyser-Spigot.jar
+        ├── Floodgate-Spigot.jar
+        ├── ViaVersion.jar
+        └── floodgate/
+            └── key.pem          # NEVER touched by install.py or update.py
 ```
 
-There are no Python files yet — `server/` and `docs/` only contain `.gitkeep` placeholders plus the AWS auth doc.
+### Deploy workflow
 
-## Public-repo hygiene
+For an existing host (where re-running `install.py` is undesired), push updater changes via:
 
-This is a public GitHub repo. Never commit, paste into PR descriptions, or echo to logs:
+```bash
+./scripts/server/deploy-updater.sh   # reads SSH details from .env
+```
 
-- The AWS account ID (12 digits) — redact to `<account-id>` or `<redacted>`. The inventory script already redacts.
-- Real `.env` values: SSH host / user / PEM path, `MC_AWS_PROFILE` if it identifies the operator.
-- `infra/backend-configs/*.hcl` (only `*.hcl.example` is committed).
-- `infra/aws-inventory.json` (operator-specific data — cross-account bucket names, personal-domain DNS records,
-  M365 verification tokens, IAM usernames — even with the account ID redacted).
-- Anything from `~/.aws/`, including SSO start URLs.
+The script rsyncs `update.py` + `_common.py`, renames `update.py` → `minecraft-update.py` with `sudo install`, then
+invokes `--install-systemd-units` on the host.
 
-`.env`, `*.pem`, `*.tfvars`, real `*.hcl` backend configs, and the inventory snapshot are already gitignored.
+## Hard constraints
 
-## Project rules
+- **`plugins/floodgate/key.pem` is never written.** Both `install.py` and `update.py` check this as an invariant.
+  Regenerating the key breaks Bedrock auth for every existing player.
+- **Paper is never bumped across Minecraft versions.** `update.py` clamps Paper to the running MC version's build
+  stream. Moving MC versions requires re-running `install.py` with `--mc-version`.
+- **All downloads are sha256-verified** before being placed. The API's reported hash is compared against the downloaded
+  bytes; mismatches delete the download and raise `ChecksumMismatchError`.
+- **Bash scripts target macOS bash 3.2**: no `mapfile`, no `${var,,}`, no associative arrays.
 
-Topic-specific instructions live in `.claude/rules/` and load alongside this file. They cover Terraform conventions,
-Python style, line length (120 char wrap in `.md` / `.py` / `.tf` / `.tfvars` / `.hcl` / `.yml` / `.yaml` / `.sh`),
-dependency vetting via the `vet-dependency` skill, scripted infrastructure setup (no prose-recipe operator steps —
-ship a script under `scripts/`), harness-format enforcement, external-API grounding, and skill matching on
-redirected intent. Read the relevant rule before touching the matching file type or planning operator-facing work.
+## `.env` setup
+
+Copy `.env.example` to `.env` and fill in:
+
+```
+MC_SSH_HOST   # LightSail static IP or DNS name
+MC_SSH_USER   # SSH user (default: ubuntu)
+MC_SSH_KEY    # Path to PEM private key
+MC_AWS_PROFILE # AWS SSO profile name (see docs/aws-auth-setup.md)
+```
+
+`scripts/aws/verify-credentials.sh` validates the AWS profile; run it whenever AWS calls fail.

--- a/README.md
+++ b/README.md
@@ -1,97 +1,82 @@
 # aws-hosted-minecraft
 
-A personal-scale Minecraft server hosted on AWS LightSail, with infrastructure managed by Terraform and operator
-workflows captured in committed scripts and docs. Designed for reproducibility — a forked clone with a fresh AWS
-account should be able to stand up an equivalent stack from this repo plus its own secrets.
+An AWS LightSail-hosted Minecraft server — Paper + Geyser + Floodgate + ViaVersion for Java/Bedrock crossplay — with
+infrastructure managed by Terraform and on-host operations captured in idempotent scripts. Fork this repo, point it
+at a fresh AWS account, fill in a few `.env` values, and bring up an equivalent server end to end without re-deriving
+any of the steps.
 
-## Status
+## What you get
 
-The repo was reset on 2026-05-09 to reverse-engineer a hand-built deployment that pre-dated source-controlled
-infrastructure. Two foundational issues drive the work:
-
-- **#4** (closed,
-  [PR #9](https://github.com/brandonavant/aws-hosted-minecraft/pull/9)) — AWS LightSail infrastructure imported
-  into Terraform. `terraform plan` is zero-changes against the live deployment.
-- **#5** (closed) — initial state-capture effort. Superseded by #11 once it became clear the deliverable should be
-  an executable provisioner, not a captured runbook.
-- **#11** (closed) — idempotent Python provisioner under `scripts/server/install.py` that takes a fresh LightSail
-  Ubuntu 22.04 instance with the data volume re-attached and produces a running Paper + Geyser + Floodgate +
-  ViaVersion crossplay server.
-- **#14** (in flight) — idempotent Python updater under `scripts/server/update.py`, run on a systemd timer, that
-  keeps Geyser / Floodgate / Paper / ViaVersion current so Bedrock clients stay connectable when Mojang ships a
-  protocol bump.
-
-## What's deployed
-
-- **Compute** — AWS LightSail Ubuntu 22.04 instance (`large_3_0` bundle) in `us-east-1a`.
-- **Storage** — 128 GB LightSail data disk attached at `/dev/xvdf` for the world directory.
-- **Networking** — a static LightSail IPv4 address bound to the instance.
-- **DNS** — `mc.bytehorizonforge.com` A-record points at the static IP (Route 53).
-- **Firewall** — Java Edition (TCP 25565), Bedrock Edition (UDP 19132), HTTP (TCP 80), and SSH (TCP 22, IPv4
-  restricted to LightSail Connect's range). Open issue
-  [#8](https://github.com/brandonavant/aws-hosted-minecraft/issues/8) tracks tightening rules that the inventory
-  script flagged.
-- **Backups** — LightSail AutoSnapshot daily at 11:00 UTC.
-
-The Terraform stack covers everything in this list except the `ssh-mcserver` key pair (the AWS provider docs
-forbid importing it) and LightSail snapshots (no Terraform resource exists for this provider). See
-`infra/README.md` for the full list of deliberately-unmanaged resources and the rationale.
+- **Compute** — AWS LightSail Ubuntu 22.04 instance (`large_3_0` bundle) in `us-east-1a`, fronted by a static IPv4
+  address.
+- **Storage** — 128 GB LightSail data disk attached at `/dev/xvdf` and mounted at `/srv/minecraft` for the world,
+  plugin state, and the Floodgate key.
+- **DNS** — Route 53 A-record pointing a subdomain at the static IP (the live deployment uses
+  `mc.bytehorizonforge.com`; forks override via Terraform variables).
+- **Firewall** — Java Edition on TCP 25565, Bedrock Edition on UDP 19132 (IPv4 + IPv6), HTTP on TCP 80, and SSH on
+  TCP 22 with the IPv4 source restricted to LightSail Connect's range.
+- **Backups** — LightSail AutoSnapshot scheduled daily.
+- **Server stack** — Paper (Java edition core), Geyser + Floodgate (Bedrock-client crossplay without separate
+  accounts), and ViaVersion (protocol bridging so older clients stay compatible across Mojang version bumps).
+- **Nightly auto-update** — an on-host systemd timer that bumps Paper / Geyser / Floodgate / ViaVersion when upstream
+  ships new builds, with sha256-based skip-when-unchanged behavior and hard refusal to bump Paper across Minecraft
+  versions or to overwrite the Floodgate key.
 
 ## Repo layout
 
 | Path                | Purpose                                                                            |
 |---------------------|------------------------------------------------------------------------------------|
 | `infra/bootstrap/`  | Terraform layer that provisions the S3 + DynamoDB remote-state backend.            |
-| `infra/`            | Main Terraform layer — imports and manages the live LightSail deployment.          |
+| `infra/`            | Main Terraform layer — manages the live LightSail deployment.                      |
 | `scripts/aws/`      | Operator-facing AWS scripts: credential verification, drift inventory.             |
 | `scripts/server/`   | On-host scripts: provisioner, updater, `deploy-updater.sh`, tests.                 |
 | `docs/`             | Long-form operator walkthroughs (currently: AWS CLI auth via IAM Identity Center). |
 | `server/`           | Reserved for on-host server state captures (placeholder).                          |
 | `.claude/`          | Project rules and skills used by Claude Code.                                      |
 
-Per-directory READMEs in `infra/` and `infra/bootstrap/`, plus `docs/aws-auth-setup.md`, carry the detail.
+Per-directory READMEs in `infra/` and `infra/bootstrap/`, plus `docs/aws-auth-setup.md`, carry the depth.
 
 ## Setup from scratch (forking operators)
 
-1. **AWS authentication** — follow `docs/aws-auth-setup.md` end-to-end (Checkpoints A–F). Ends with
+1. **AWS authentication** — follow `docs/aws-auth-setup.md` end-to-end (Checkpoints A–F). It ends with
    `./scripts/aws/verify-credentials.sh` exiting clean.
-2. **Bootstrap layer** — `cd infra/bootstrap`, copy `terraform.auto.tfvars.example` to `terraform.auto.tfvars`,
-   pick a globally-unique S3 bucket name, then `terraform init` and `terraform apply`. See
-   `infra/bootstrap/README.md` for the full first-run workflow and a recovery path if the local state is lost.
+2. **Bootstrap layer** — `cd infra/bootstrap`, copy `terraform.auto.tfvars.example` to `terraform.auto.tfvars`, pick
+   a globally-unique S3 bucket name, then `terraform init` and `terraform apply`. See `infra/bootstrap/README.md` for
+   the first-run workflow and the recovery path if the local state file is lost.
 3. **Main layer** — `cd infra`, copy `backend-configs/prod.hcl.example` to `prod.hcl` with the bootstrap layer's
-   outputs, then `terraform init -backend-config=backend-configs/prod.hcl`. The committed `.tf` files match the
-   shape of the existing live deployment, so the import path documented in `infra/README.md` is the supported one
-   today; a clean greenfield apply has not been exercised and may surface differences that need to be reconciled.
-4. **Provision the host** — once Terraform has stood up the LightSail instance and the data volume is attached
-   and mounted at `/srv/minecraft`, SSH in and run the provisioner:
+   outputs, then `terraform init -backend-config=backend-configs/prod.hcl`. The committed `.tf` files describe the
+   live deployment shape, so the supported path today is the import workflow in `infra/README.md`; a clean greenfield
+   apply has not been exercised end to end and may surface differences that need reconciling.
+4. **Provision the host** — once Terraform has the LightSail instance up and the data volume is attached and mounted
+   at `/srv/minecraft`, SSH in and run the provisioner. It is idempotent (re-runs are no-ops when state matches),
+   pins Paper / Geyser / Floodgate / ViaVersion versions via flags (defaulting to the volume's existing state), and
+   refuses to regenerate the Floodgate key unless `--allow-fresh-floodgate-key` is passed:
 
    ```bash
    sudo python3 scripts/server/install.py --help
    ```
 
-   The script is idempotent (re-runs are no-ops when state matches), pins Paper / Geyser / Floodgate / ViaVersion
-   versions via flags (defaulting to the volume's existing state), and refuses to regenerate the Floodgate key
-   unless `--allow-fresh-floodgate-key` is passed. See the script's docstring and `--dry-run` for details.
+5. **Deploy the nightly updater** — from the operator workstation, run `scripts/server/deploy-updater.sh` (reads
+   `.env` for SSH details, rsyncs `update.py` + `_common.py` to `/usr/local/sbin/`, then installs the systemd timer
+   and service via the updater's `--install-systemd-units` mode). Idempotent end to end. Prefer this over re-running
+   `install.py` against a host that was not originally provisioned with it.
 
 ## Operating the live server
 
-- `./scripts/aws/verify-credentials.sh` — read-only AWS auth check. Run this whenever an AWS call starts failing;
-  it surfaces expired SSO tokens, missing region config, and wrong-permission-set ARNs with a copy-paste recovery
+- `./scripts/aws/verify-credentials.sh` — read-only AWS auth check. Run this whenever an AWS call starts failing; it
+  surfaces expired SSO tokens, missing region config, and wrong-permission-set ARNs with a copy-paste recovery
   command.
 - `./scripts/aws/inventory.sh` — snapshot every relevant AWS resource into `infra/aws-inventory.json` (gitignored,
-  account ID redacted). Keep a local baseline copy and `diff` against future runs for drift detection on
-  resources Terraform doesn't manage (key pair, instance snapshots, unrelated records in the shared
-  `bytehorizonforge.com` zone).
+  account ID redacted). Keep a local baseline and `diff` against future runs for drift detection on resources
+  Terraform does not manage (key pair, instance snapshots, unrelated records in a shared Route 53 zone).
 - `terraform fmt -recursive` / `terraform validate` / `terraform plan` — routine Terraform hygiene. `apply` and
-  `destroy` are operator-only.
+  `destroy` stay operator-driven.
 - `scripts/server/update.py --help` — the on-host updater (lands at `/usr/local/sbin/minecraft-update.py`). Runs
   daily under `minecraft-update.timer` (fires at `*-*-* 10:00:00 UTC` with a `RandomizedDelaySec=3600` jitter —
-  ~5 AM CDT, genuine off-peak). Sha256-driven: skips when on-disk jars match the API. Refuses to bump Paper
-  across MC versions, never touches `plugins/floodgate/key.pem`.
-- `scripts/server/deploy-updater.sh --help` — operator-side script for the existing hand-built live host. Reads
-  `.env` for SSH details, rsyncs `update.py` + `_common.py` to `/usr/local/sbin/`, then invokes the updater's
-  `--install-systemd-units` mode to drop the timer + service units. Idempotent end-to-end. Use this rather than
-  re-running `install.py` against a host that was never tested with the provisioner.
+  ~5 AM CDT, genuine off-peak). Sha256-driven: skips when on-disk jars match the API. Refuses to bump Paper across
+  Minecraft versions; never touches `plugins/floodgate/key.pem`.
+- `scripts/server/deploy-updater.sh --help` — operator-side script for redeploying the updater payload + systemd
+  units to an existing host without re-running `install.py`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ any of the steps.
   address.
 - **Storage** — 128 GB LightSail data disk attached at `/dev/xvdf` and mounted at `/srv/minecraft` for the world,
   plugin state, and the Floodgate key.
-- **DNS** — Route 53 A-record pointing a subdomain at the static IP (the live deployment uses
-  `mc.bytehorizonforge.com`; forks override via Terraform variables).
+- **DNS** — Route 53 A-record pointing `<mc_subdomain>.<domain_zone>` (both Terraform variables) at the static IP.
+  The hosted zone must already exist in the account; the stack looks it up via a data source rather than creating it.
 - **Firewall** — Java Edition on TCP 25565, Bedrock Edition on UDP 19132 (IPv4 + IPv6), HTTP on TCP 80, and SSH on
-  TCP 22 with the IPv4 source restricted to LightSail Connect's range.
+  TCP 22 restricted to LightSail Connect's range plus the operator's current public IPv4 (auto-detected via
+  `api.ipify.org` at plan time, or pinned explicitly via `ssh_allowed_cidrs`). IPv6 SSH is intentionally closed.
 - **Backups** — LightSail AutoSnapshot scheduled daily.
 - **Server stack** — Paper (Java edition core), Geyser + Floodgate (Bedrock-client crossplay without separate
   accounts), and ViaVersion (protocol bridging so older clients stay compatible across Mojang version bumps).

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -23,3 +23,23 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fb2494a6c92118055cfb2c114a4fe5c750946a1b0d6be6bf02ab3e37a091fb8b",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.5.0"
+  constraints = "~> 3.5.0"
+  hashes = [
+    "h1:dl73+8wzQR++HFGoJgDqY3mj3pm14HUuH/CekVyOj5s=",
+    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
+    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
+    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
+    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
+    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
+    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
+    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
+    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
+    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
+    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -71,11 +71,12 @@ terraform import aws_lightsail_disk.mcserver_data              disk-mcserver-pro
 terraform import aws_lightsail_disk_attachment.mcserver_data   'disk-mcserver-prod,mcserver-prod'
 terraform import aws_lightsail_static_ip.mcserver              ip-mcserver-prod
 terraform import aws_lightsail_static_ip_attachment.mcserver   ip-mcserver-prod
-terraform import aws_route53_record.mc                         'Z09024551TI8L9018Y7IE_mc.bytehorizonforge.com_A'
+terraform import aws_route53_record.mc                         '<zone-id>_<mc_subdomain>.<domain_zone>_A'
 ```
 
-The `bytehorizonforge.com` Route 53 zone is **not** imported — it is read via a `data` source instead. See
-[Why the bytehorizonforge zone is a data source](#why-the-bytehorizonforge-zone-is-a-data-source).
+Substitute your own zone ID (from the Route 53 console) and the values you set for `mc_subdomain` and
+`domain_zone` in `terraform.auto.tfvars`. The hosted zone itself is **not** imported — it is read via a `data`
+source instead. See [Why the hosted zone is a data source](#why-the-hosted-zone-is-a-data-source).
 
 ## Resources that can't be imported
 
@@ -94,28 +95,28 @@ state. Each is handled deliberately:
   `aws_lightsail_instance_snapshot` resource at all. Existing snapshots live in AWS independently of Terraform; the
   AutoSnapshot add-on on the instance creates new ones daily as configured (`snapshot_time = "11:00"` UTC).
 
-## Why the bytehorizonforge zone is a data source
+## Why the hosted zone is a data source
 
-The `bytehorizonforge.com.` zone pre-existed this project and hosts records for unrelated concerns — specifically
-an Azure M365 email setup at `auth.bytehorizonforge.com.` (MX, TXT, two DKIM CNAMEs). The Minecraft Terraform does
-**not** own that zone; it merely places one record (`mc.bytehorizonforge.com.`) inside it.
+The zone named by `var.domain_zone` is typically shared with other concerns (e.g., email/MX/TXT/DKIM records for
+the same apex domain). The Minecraft Terraform does **not** own that zone; it merely places one record
+(`<mc_subdomain>.<domain_zone>.`) inside it.
 
 Expressing that with a `data "aws_route53_zone"` block instead of `resource "aws_route53_zone"` keeps the ownership
 boundary truthful: Terraform looks up the zone, but cannot create it, modify it, or destroy it. Zone-level
 attributes (NS, SOA, comment, tags) and unrelated records are entirely outside this stack's reach.
 
-If the zone ever becomes Minecraft-only (e.g., the Azure email records are retired or migrated), the data source
-can be flipped to a resource block by replacing `data "aws_route53_zone"` with `resource "aws_route53_zone"`,
-adding it to state via `terraform import aws_route53_zone.bytehorizonforge <zone_id>`, and updating the `aws_route53_record.mc`
-reference from `data.…` to `aws_route53_zone.bytehorizonforge.zone_id`.
+If your zone ever becomes Minecraft-only, the data source can be flipped to a resource block by replacing
+`data "aws_route53_zone"` with `resource "aws_route53_zone"`, adding it to state via
+`terraform import aws_route53_zone.mc <zone_id>`, and updating the `aws_route53_record.mc` reference from
+`data.…` to `aws_route53_zone.mc.zone_id`.
 
 ## Drift detection
 
 The primary drift signal is `terraform plan` against the imported state — when something has changed in AWS that
 Terraform manages, plan will show it.
 
-For drift in resources Terraform **doesn't** manage (e.g., the LightSail key pair, instance snapshots, the
-unrelated `auth.*` records in the `bytehorizonforge.com` zone), the inventory script is the cross-check:
+For drift in resources Terraform **doesn't** manage (e.g., the LightSail key pair, instance snapshots, any
+unrelated records sharing the Route 53 zone), the inventory script is the cross-check:
 
 ```bash
 # Keep a local baseline once you're at a known-good state.
@@ -127,9 +128,9 @@ cp infra/aws-inventory.json infra/aws-inventory.baseline.json
 diff infra/aws-inventory.baseline.json infra/aws-inventory.json
 ```
 
-Both files are gitignored — the snapshot pulls in operator-specific data (cross-account bucket names, personal
-domain DNS records, Azure M365 verification tokens, IAM usernames) that doesn't belong in a public repo even with
-the AWS account ID redacted.
+Both files are gitignored — the snapshot pulls in operator-specific data (cross-account bucket names, DNS records
+for shared zones, email-provider verification tokens, IAM usernames) that doesn't belong in a public repo even
+with the AWS account ID redacted.
 
 ## Tags
 
@@ -142,12 +143,12 @@ expected.
 
 | File              | Concern                                                                |
 |-------------------|------------------------------------------------------------------------|
-| `providers.tf`    | Terraform + AWS provider version pins; S3 backend block.               |
-| `variables.tf`    | `region`, `aws_profile`.                                               |
-| `lightsail.tf`    | LightSail instance + firewall rules.                                   |
+| `providers.tf`    | Terraform + AWS + http provider version pins; S3 backend block.        |
+| `variables.tf`    | `region`, `aws_profile`, `domain_zone`, `mc_subdomain`, `ssh_allowed_cidrs`. |
+| `lightsail.tf`    | LightSail instance + firewall rules (incl. dynamic SSH allowlist).     |
 | `storage.tf`      | Attached data disk + disk attachment.                                  |
 | `networking.tf`   | Static IP + IP-to-instance attachment.                                 |
-| `dns.tf`          | `bytehorizonforge.com` Route 53 zone + `mc.` A record.                 |
+| `dns.tf`          | Route 53 zone data lookup + `<mc_subdomain>.<domain_zone>` A record.   |
 | `outputs.tf`      | Public IP, DNS name, name servers.                                     |
 | `backend-configs/prod.hcl.example` | Template for the operator's gitignored `prod.hcl`.    |
 | `aws-inventory.json` | Local-only AWS-state snapshot (gitignored). Generated by `scripts/aws/inventory.sh`. |

--- a/infra/dns.tf
+++ b/infra/dns.tf
@@ -1,15 +1,15 @@
-# The bytehorizonforge.com hosted zone pre-existed this project and hosts records for
-# unrelated concerns (an Azure M365 email setup under auth.*). It is therefore looked up
-# via a data source rather than imported as a resource — this Terraform does not own the
-# zone, only the single record that points the Minecraft DNS at the LightSail static IP.
+# The Route 53 hosted zone (var.domain_zone) is looked up via a data source rather than declared as a
+# resource. This keeps Terraform's ownership boundary truthful: the stack can create / update / delete the
+# single A record below, but it cannot create, modify, or destroy the zone itself or any unrelated records
+# inside it (e.g., email/MX/TXT records that may share the same apex domain). The zone must already exist.
 
-data "aws_route53_zone" "bytehorizonforge" {
-  name = "bytehorizonforge.com"
+data "aws_route53_zone" "mc" {
+  name = var.domain_zone
 }
 
 resource "aws_route53_record" "mc" {
-  zone_id = data.aws_route53_zone.bytehorizonforge.zone_id
-  name    = "mc.bytehorizonforge.com"
+  zone_id = data.aws_route53_zone.mc.zone_id
+  name    = "${var.mc_subdomain}.${var.domain_zone}"
   type    = "A"
   ttl     = 300
   records = [aws_lightsail_static_ip.mcserver.ip_address]

--- a/infra/lightsail.tf
+++ b/infra/lightsail.tf
@@ -13,6 +13,17 @@ resource "aws_lightsail_instance" "mcserver" {
   }
 }
 
+# Operator's current public IPv4, fetched only when var.ssh_allowed_cidrs is empty.
+# Used to populate the SSH allowlist with a /32 of the host running terraform.
+data "http" "operator_ip" {
+  count = length(var.ssh_allowed_cidrs) > 0 ? 0 : 1
+  url   = "https://api.ipify.org"
+}
+
+locals {
+  ssh_allowed_cidrs = length(var.ssh_allowed_cidrs) > 0 ? var.ssh_allowed_cidrs : ["${chomp(data.http.operator_ip[0].response_body)}/32"]
+}
+
 resource "aws_lightsail_instance_public_ports" "mcserver" {
   instance_name = aws_lightsail_instance.mcserver.name
 
@@ -45,12 +56,14 @@ resource "aws_lightsail_instance_public_ports" "mcserver" {
     ipv6_cidrs = ["::/0"]
   }
 
+  # SSH is restricted to AWS's lightsail-connect range plus the operator's current IPv4 (or
+  # var.ssh_allowed_cidrs when set). IPv6 SSH is intentionally not opened — dualstack would otherwise
+  # widen this rule to every IPv6 host on the internet.
   port_info {
     protocol          = "tcp"
     from_port         = 22
     to_port           = 22
-    cidrs             = ["198.148.30.0/32"]
-    ipv6_cidrs        = ["::/0"]
+    cidrs             = local.ssh_allowed_cidrs
     cidr_list_aliases = ["lightsail-connect"]
   }
 }

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -10,6 +10,10 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.44.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 3.5.0"
+    }
   }
 }
 

--- a/infra/terraform.auto.tfvars.example
+++ b/infra/terraform.auto.tfvars.example
@@ -1,10 +1,25 @@
-# Copy to terraform.auto.tfvars and override values as needed. terraform.auto.tfvars is gitignored.
+# Copy to terraform.auto.tfvars and override values as needed. terraform.auto.tfvars is gitignored
+# because domain_zone identifies your live deployment and ssh_allowed_cidrs may reveal your home IP.
 #
 #   cp terraform.auto.tfvars.example terraform.auto.tfvars
 #   $EDITOR terraform.auto.tfvars
-#
-# Defaults match the project's IdC profile and us-east-1 region. Override only if your
-# .env points at a different profile.
-#
+
+# REQUIRED — apex domain of an existing Route 53 hosted zone in this account. The Minecraft A record
+# is placed at "<mc_subdomain>.<domain_zone>". The zone is looked up via a data source; this stack
+# does not create it.
+domain_zone = "example.com"
+
+# Optional — subdomain label for the A record (default: "mc"). The full FQDN becomes
+# "<mc_subdomain>.<domain_zone>".
+# mc_subdomain = "mc"
+
+# Optional — IPv4 CIDRs allowed to reach SSH (port 22), in addition to AWS's lightsail-connect range.
+# When unset (default), the operator's current public IPv4 is auto-detected via api.ipify.org and
+# pinned as a /32 at plan/apply time. Set explicitly to lock in a stable CIDR (e.g., VPN / CI egress)
+# or to avoid the network call on every plan.
+# ssh_allowed_cidrs = ["203.0.113.42/32"]
+
+# Optional — defaults match the project's IdC profile and region. Override only if your .env points
+# at a different profile.
 # region      = "us-east-1"
 # aws_profile = "mc-aws"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -9,3 +9,20 @@ variable "aws_profile" {
   type        = string
   default     = "mc-aws"
 }
+
+variable "domain_zone" {
+  description = "Apex domain of the Route 53 hosted zone that already exists in this account (e.g. \"example.com\"). The zone is looked up via a data source; this stack does not create it."
+  type        = string
+}
+
+variable "mc_subdomain" {
+  description = "Subdomain label under domain_zone for the Minecraft A record. The full FQDN becomes \"<mc_subdomain>.<domain_zone>\"."
+  type        = string
+  default     = "mc"
+}
+
+variable "ssh_allowed_cidrs" {
+  description = "IPv4 CIDRs allowed to reach SSH (port 22), in addition to AWS's lightsail-connect range. When empty, the operator's current public IP is auto-detected via api.ipify.org and pinned as a /32."
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- Drops the "Status" section that enumerated open/closed issues by number, plus the reverse-engineering origin story and Azure-rename framing.
- Reframes "What's deployed" as a present-tense "What you get" feature list (compute, storage, DNS, firewall, backups, the Paper + Geyser + Floodgate + ViaVersion stack, nightly auto-update).
- Keeps the salvageable setup walkthrough and operations sections, with all commands routed through committed scripts per `.claude/rules/scripted-infra-setup.md`.

Closes #15

## Test plan
- [ ] Rendered README reads as "what this repo provisions and how to stand it up" without referencing issue numbers, the 2026-05-09 reset, or the Azure rename.
- [ ] All internal links resolve (`docs/aws-auth-setup.md`, per-directory READMEs, script paths, `LICENSE`).
- [ ] All lines wrap at 120 chars or fewer (line-length rule).
- [ ] Setup steps point at committed scripts/docs rather than inlining commands.
